### PR TITLE
[fix] STDL Loading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ SOURCES = $(CLI_DIR)/main.c \
           $(PARSER_DIR)/parser.c \
           $(PARSER_DIR)/ast.c \
           $(COMPILER_DIR)/compiler.c \
+	  $(COMPILER_DIR)/stdl.c \
           $(COMPILER_PLATFORMS)/linux.c \
           $(COMPILER_PLATFORMS)/windowsx86-64.c \
           $(UTILS_DIR)/hashes.c \

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,7 @@ UTILS_DIR = $(SRC_DIR)/utils
 BUILD_DIR = build
 
 # Source files
-SOURCES = $(CLI_DIR)/main.c \
-          $(LEXER_DIR)/lexer.c \
+SOURCES = $(LEXER_DIR)/lexer.c \
           $(LEXER_DIR)/tokens.c \
           $(PARSER_DIR)/parser.c \
           $(PARSER_DIR)/ast.c \
@@ -39,25 +38,27 @@ SOURCES = $(CLI_DIR)/main.c \
           $(COMPILER_PLATFORMS)/linux.c \
           $(COMPILER_PLATFORMS)/windowsx86-64.c \
           $(UTILS_DIR)/hashes.c \
-          
-
-# Object files
-OBJECTS = $(SOURCES:%.c=$(BUILD_DIR)/%.o)
 
 # Executable name
 TARGET = quickfall$(TARGET_EXTENSION)
+BENCH_TARGET = bench$(TARGET_EXTENSION)
 
 # Default target
 all: check_commands $(TARGET)
+bench: check_commands $(BENCH_TARGET)
+
+OBJECTS = $(SOURCES:%.c=$(BUILD_DIR)/%.o)
 
 # Check commands target
 check_commands:
 	@echo "Using compiler: gcc"
 	@echo "Operating System: $(DETECTED_OS)"
 	$(CHECK_COMMANDS)
+	@echo "Sources: $(SOURCES)"
 
 # Create build directory structure
 $(BUILD_DIR):
+	$(MKDIR) $(BUILD_DIR)$(PATHSEP)benchmarks
 	$(MKDIR) $(BUILD_DIR)$(PATHSEP)$(SRC_DIR)$(PATHSEP)cli
 	$(MKDIR) $(BUILD_DIR)$(PATHSEP)$(SRC_DIR)$(PATHSEP)compiler
 	$(MKDIR) $(BUILD_DIR)$(PATHSEP)$(SRC_DIR)$(PATHSEP)compiler$(PATHSEP)platforms
@@ -71,7 +72,12 @@ $(BUILD_DIR)/%.o: %.c | $(BUILD_DIR)
 
 # Link object files
 $(TARGET): $(OBJECTS)
-	gcc $(OBJECTS) -g -o $@
+	gcc $(CFLAGS) -c src/cli/main.c -o build/src/cli/main.o
+	gcc build/src/cli/main.o $(OBJECTS) -g -o $@
+
+$(BENCH_TARGET): $(OBJECTS)
+	gcc $(CFLAGS) -c benchmarks/main.c -o build/benchmarks/main.o
+	gcc build/benchmarks/main.o $(OBJECTS) -g -o $@
 
 # Clean build files
 clean:

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -26,6 +26,7 @@ char* compile(struct ASTNode* node, char* platform) {
     enum Platform p = platformFromString(platform);
 
     struct CompilingContext ctx;
+    ctx.section = 1;
 
     // Default size buffers for now, todo: use realloc for less memory usage.
     ctx.defaultSection = malloc(512);

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -39,44 +39,7 @@ char* compile(struct ASTNode* node, char* platform) {
     memset(ctx.main, 0, 1024);
     strcat(ctx.main, "\nmain:");
 
-    while(node->next != NULL) {
-        node = node->next;
-
-        if(node->type == AST_USE_STDL) {
-            char fileName[32] = "stdl/";
-
-            //
-            // todo: move stdl loading somewhere else
-            //
-
-            strcat(fileName, node->right->value);
-            strcat(fileName, ".qfall"); // Do not dynamically check the extension for now.
-
-            FILE* fptr = fopen(fileName, "r");
-
-            if(fptr == NULL) {
-                printf("Error: Couldn't import %s from the standart library! Are you sure it is correct?\n");
-                continue;
-            }
-
-
-            fseek(fptr, 0, SEEK_END);
-            int size = ftell(fptr);
-            fseek(fptr, 0, SEEK_SET);
-
-            char* buff = (char*) malloc(size);
-            fread(buff, 1, size, fptr);
-            fclose(fptr);
-
-            struct LexerResult result = runLexer(buff);
-            struct ASTNode* n = runParser(result);
-
-            win64(ctx, n, 0);
-        }
-        else {
-            win64(ctx, node, 0);
-        }
-    }
+    win64(ctx, node, 0); //todo: change this based on the platform
 
     char* buff = malloc(2048);
     memset(buff, 0, 2048);

--- a/src/compiler/platforms/windowsx86-64.c
+++ b/src/compiler/platforms/windowsx86-64.c
@@ -7,6 +7,7 @@
 
 #include "../../parser/ast.h"
 #include "../compiler.h"
+#include "../stdl.h"
 
 /**
  * Gets the assembly output of the AST Node.
@@ -109,6 +110,9 @@ void win64(struct CompilingContext ctx, struct ASTNode* node, int genericState) 
 
             win64(ctx, n, (node->type == AST_GENERIC ? 0 : 1));
         }
+    }
+    else if(node->type == AST_USE_STDL) {
+	loadAndDump(ctx, node->right->value);
     }
     else {
         printf("Error: AST Node of type %d could not be converted to x64 assembly!\n", node->type);

--- a/src/compiler/platforms/windowsx86-64.c
+++ b/src/compiler/platforms/windowsx86-64.c
@@ -50,13 +50,13 @@ void win64(struct CompilingContext ctx, struct ASTNode* node, int genericState) 
         }
         else {
             // If the function isn't an internal, jump to it!
-	    if(node->right->next != NULL) { 
+	    if(node->right->next != NULL) {
             	int argCount = 0;
             	while(node->right->next != NULL) {
 			node->right = node->right->next;
 
                 	char b[5] = {""};
-                	sprintf(b, "%d", ctx.section++ + 1);
+                	snprintf(b, 5, "%d", ctx.section++);
 
                 	strcat(ctx.sections, "\n.");
                 	strcat(ctx.sections, "LC");
@@ -67,7 +67,6 @@ void win64(struct CompilingContext ctx, struct ASTNode* node, int genericState) 
                 	strcat(ctx.sections, "\\0\"");
 
                 	strcat(funcBuff, "\n    leaq    .LC");
-
                 	strcat(funcBuff, b);
                 	strcat(funcBuff, "(%rip), %rax");
                 	strcat(funcBuff, "\n    movq %rax,");
@@ -110,6 +109,7 @@ void win64(struct CompilingContext ctx, struct ASTNode* node, int genericState) 
 
             win64(ctx, n, (node->type == AST_GENERIC ? 0 : 1));
         }
+
     }
     else if(node->type == AST_USE_STDL) {
 	loadAndDump(ctx, node->right->value);

--- a/src/compiler/platforms/windowsx86-64.c
+++ b/src/compiler/platforms/windowsx86-64.c
@@ -48,8 +48,7 @@ void win64(struct CompilingContext ctx, struct ASTNode* node, int genericState) 
             strcat(funcBuff, node->right->next->next->next->value);
         }
         else {
-            // If the function isn't an internal, jump to it.
-	
+            // If the function isn't an internal, jump to it!
 	    if(node->right->next != NULL) { 
             	int argCount = 0;
             	while(node->right->next != NULL) {
@@ -103,7 +102,7 @@ void win64(struct CompilingContext ctx, struct ASTNode* node, int genericState) 
         win64(ctx, node->right, genericState); // Parses the AST_GENERIC Node.
         strcat(ctx.sections, "\n    ret\n");
     }
-    else if(node->type == AST_GENERIC || node->type == AST_FUNCTION_GENERIC) {
+    else if(node->type == AST_FUNCTION_GENERIC || node->type == AST_GENERIC) {
         struct ASTNode* n = node;
         while (n->next != NULL) {
             n = n->next;

--- a/src/compiler/stdl.c
+++ b/src/compiler/stdl.c
@@ -1,0 +1,47 @@
+/**
+ * The code in charge of managing the standart library usage in Quickfall.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "./compiler.h"
+#include "./platforms/windowsx86-64.h"
+
+#include "../lexer/lexer.h"
+#include "../parser/parser.h"
+#include "../parser/ast.h"
+
+/**
+ * Loads a component (a file) of the standart library and dump its contents into the assembly output.
+ * @param ctx the compiling context of the currently running compile attempt.
+ * @param component the component name (file name) of the part to load.
+ */
+void loadAndDump(struct CompilingContext ctx, char* component) {
+	char fileName[32] = "stdl/";
+	strcat(fileName, component);
+	strcat(fileName, ".qfall");
+
+	FILE* fptr = fopen(fileName, "r");
+
+	if(fptr == NULL) {
+		printf("Error: Could not find STDL component named %s!", component);
+		return;
+	}
+
+	fseek(fptr, 0, SEEK_END);
+	int size = ftell();
+	fseel(fptr, 0, SEEK_SET);
+
+	char* buff = malloc(size + 1);
+	buff[size] = '\0';
+
+	fread(buff, 1, size, fptr);
+	fclose(fptr);
+
+	struct LexerResult result = runLexer(buff);
+	struct ASTNode* node = runParser(result);
+
+	win64(ctx, node, 0); // todo: change this according to the platform selected
+}

--- a/src/compiler/stdl.c
+++ b/src/compiler/stdl.c
@@ -31,8 +31,8 @@ void loadAndDump(struct CompilingContext ctx, char* component) {
 	}
 
 	fseek(fptr, 0, SEEK_END);
-	int size = ftell();
-	fseel(fptr, 0, SEEK_SET);
+	int size = ftell(fptr);
+	fseek(fptr, 0, SEEK_SET);
 
 	char* buff = malloc(size + 1);
 	buff[size] = '\0';

--- a/src/compiler/stdl.h
+++ b/src/compiler/stdl.h
@@ -1,0 +1,12 @@
+/**
+ * The code in charge of managing the standart library usage in Quickfall.
+ */
+
+#include "./compiler.h"
+
+/**
+ * Loads a component (a file) of the standart library and dump its content into the assembly output.
+ * @param ctx the compiling context of the currently running compiling.
+ * @param component the component name (file name) of the part to load.
+ */
+void loadAndDump(struct CompilingContext ctx, char* component);

--- a/src/compiler/stdl.h
+++ b/src/compiler/stdl.h
@@ -2,6 +2,9 @@
  * The code in charge of managing the standart library usage in Quickfall.
  */
 
+#ifndef COMPILER_STDL
+#define COMPILER_STDL
+
 #include "./compiler.h"
 
 /**
@@ -10,3 +13,5 @@
  * @param component the component name (file name) of the part to load.
  */
 void loadAndDump(struct CompilingContext ctx, char* component);
+
+#endif


### PR DESCRIPTION
# Changes
- Isolated STDL loading to its own file (stdl.c and stdl.h)
- Added proper `AST_GENERIC` handling in platforms
- Fixed unsafe string operation that caused segmentation faults when using non-internally handled functions (such as STDL functions)