### PR TITLE
fix: AST value ordering rules

### DIFF
--- a/parser/src/ast/mod.rs
+++ b/parser/src/ast/mod.rs
@@ -31,6 +31,32 @@ pub mod control;
 pub mod math;
 pub mod types;
 
+pub fn parse_ast_value_dotacess(tokens: &Vec<LexerToken>, ind: &mut usize, original: PositionedResult<Box<ASTTreeNode>>) -> PositionedResult<Box<ASTTreeNode>> {
+	match &tokens[*ind].tok_type {
+		LexerTokenType::Dot => {
+			let o = &original?;
+			let k = Box::new(ASTTreeNode::clone(o.as_ref()));
+
+			if !o.is_function_call() && !o.is_var_access() {
+				return Err(tokens[*ind].make_err("Invalid dot access token!"));
+			}
+
+			*ind += 1;
+			let r = parse_ast_value(tokens, ind)?;
+
+			if r.is_function_call() {
+				return Ok(Box::new(ASTTreeNode::StructLRFunction { l: k, r }))
+			} else if r.is_var_access() {
+				return Ok(Box::new(ASTTreeNode::StructLRVariable { l: k, r }))
+			}
+
+			return Err(tokens[*ind].make_err("Invalid token type to use dot access!"));
+		},
+
+		_ => return original
+	}
+}
+
 /// Parses the post side of an AST node that can and WILL be intrepreted as a value.
 /// 
 /// This function should only be called by `parse_ast_value`

--- a/parser/src/ast/mod.rs
+++ b/parser/src/ast/mod.rs
@@ -57,6 +57,24 @@ pub fn parse_ast_value_dotacess(tokens: &Vec<LexerToken>, ind: &mut usize, origi
 	}
 }
 
+pub fn parse_ast_value_dotacess_chain_member(tokens: &Vec<LexerToken>, ind: &mut usize, original: PositionedResult<Box<ASTTreeNode>>) -> PositionedResult<Box<ASTTreeNode>> {
+	match &tokens[*ind].tok_type {
+		LexerTokenType::KEYWORD(s, hsh) => {
+			if tokens[*ind + 1].tok_type == LexerTokenType::ParenOpen {
+				let r_member = parse_function_call(tokens, ind)?;
+
+				return Ok(Box::new(ASTTreeNode::StructLRFunction { l: original?, r: r_member }))
+			}
+
+			let r_member = Box::new(ASTTreeNode::VariableReference(WithHash::new(s.clone())));
+
+			return Ok(Box::new(ASTTreeNode::StructLRVariable { l: original?, r: r_member }));
+		},
+
+		_ => return original
+	};
+}
+
 /// Parses the post side of an AST node that can and WILL be intrepreted as a value.
 /// 
 /// This function should only be called by `parse_ast_value`

--- a/parser/src/ast/mod.rs
+++ b/parser/src/ast/mod.rs
@@ -79,7 +79,7 @@ pub fn parse_ast_value_dotacess(tokens: &Vec<LexerToken>, ind: &mut usize, origi
 pub fn parse_ast_value_post_l(tokens: &Vec<LexerToken>, ind: &mut usize, original: PositionedResult<Box<ASTTreeNode>>, invoked_on_body: bool) -> PositionedResult<Box<ASTTreeNode>> {
 	match &tokens[*ind].tok_type {
 		LexerTokenType::Dot => {
-			return parse_ast_value_dotacess(tokens, ind, original);
+			return parse_ast_value_dotacess(tokens, ind, original); // TODO: check if this is required or can be removed
 		},
 
 		LexerTokenType::MathOperator(_, _) => {
@@ -157,7 +157,9 @@ pub fn parse_ast_value(tokens: &Vec<LexerToken>, ind: &mut usize) -> PositionedR
 
 			*ind += 1;
 
-			return parse_ast_value_post_l(tokens, ind, n, false);
+			let chain = parse_ast_value_dotacess(tokens, ind, n);
+
+			return parse_ast_value_post_l(tokens, ind, chain, false);
 		}
 
 		_ => return Err(tokens[*ind].make_err("Invalid token to parse as a value!"))
@@ -221,9 +223,7 @@ pub fn parse_ast_node_in_body(tokens: &Vec<LexerToken>, ind: &mut usize) -> Posi
 
 			*ind += 1;
 
-			let chain = parse_ast_value_dotacess(tokens, ind, n);
-
-			return parse_ast_value_post_l(tokens, ind, chain, true);
+			return parse_ast_value_post_l(tokens, ind, n, true);
 		},
 
 		_ => {

--- a/parser/src/ast/mod.rs
+++ b/parser/src/ast/mod.rs
@@ -221,7 +221,9 @@ pub fn parse_ast_node_in_body(tokens: &Vec<LexerToken>, ind: &mut usize) -> Posi
 
 			*ind += 1;
 
-			return parse_ast_value_post_l(tokens, ind, n, true);
+			let chain = parse_ast_value_dotacess(tokens, ind, n);
+
+			return parse_ast_value_post_l(tokens, ind, chain, true);
 		},
 
 		_ => {

--- a/parser/src/ast/mod.rs
+++ b/parser/src/ast/mod.rs
@@ -79,23 +79,7 @@ pub fn parse_ast_value_dotacess(tokens: &Vec<LexerToken>, ind: &mut usize, origi
 pub fn parse_ast_value_post_l(tokens: &Vec<LexerToken>, ind: &mut usize, original: PositionedResult<Box<ASTTreeNode>>, invoked_on_body: bool) -> PositionedResult<Box<ASTTreeNode>> {
 	match &tokens[*ind].tok_type {
 		LexerTokenType::Dot => {
-			let o = &original?;
-			let k = Box::new(ASTTreeNode::clone(o.as_ref()));
-
-			if !o.is_function_call() && !o.is_var_access() {
-				return Err(tokens[*ind].make_err("Invalid dot access token!"));
-			}
-
-			*ind += 1;
-			let r = parse_ast_value(tokens, ind)?;
-
-			if r.is_function_call() {
-				return Ok(Box::new(ASTTreeNode::StructLRFunction { l: k, r }))
-			} else if r.is_var_access() {
-				return Ok(Box::new(ASTTreeNode::StructLRVariable { l: k, r }))
-			}
-
-			return Err(tokens[*ind].make_err("Invalid token type to use dot access!"));
+			return parse_ast_value_dotacess(tokens, ind, original);
 		},
 
 		LexerTokenType::MathOperator(_, _) => {

--- a/parser/src/ast/mod.rs
+++ b/parser/src/ast/mod.rs
@@ -42,8 +42,10 @@ pub fn parse_ast_value_dotacess(tokens: &Vec<LexerToken>, ind: &mut usize, origi
 			*ind += 1;
 			let r = parse_ast_value_dotacess_chain_member(tokens, ind, Ok(original))?;
 
+			println!("Tok: {:#?}", tokens[*ind].tok_type);
+
 			if tokens[*ind].tok_type == LexerTokenType::Dot {
-				return parse_ast_value_dotacess_chain_member(tokens, ind, Ok(r)); // Continue the chain until finished
+				return parse_ast_value_dotacess(tokens, ind, Ok(r)); // Continue the chain until finished
 			}
 
 			return Ok(r);
@@ -57,6 +59,9 @@ pub fn parse_ast_value_dotacess_chain_member(tokens: &Vec<LexerToken>, ind: &mut
 	match &tokens[*ind].tok_type {
 		LexerTokenType::KEYWORD(s, hsh) => {
 			if tokens[*ind + 1].tok_type == LexerTokenType::ParenOpen {
+
+				println!("Calling function call parsing on kwd {}", s);
+
 				let r_member = parse_function_call(tokens, ind)?;
 
 				return Ok(Box::new(ASTTreeNode::StructLRFunction { l: original?, r: r_member }))
@@ -94,10 +99,6 @@ pub fn parse_ast_value_dotacess_chain_member(tokens: &Vec<LexerToken>, ind: &mut
 /// 
 pub fn parse_ast_value_post_l(tokens: &Vec<LexerToken>, ind: &mut usize, original: PositionedResult<Box<ASTTreeNode>>, invoked_on_body: bool) -> PositionedResult<Box<ASTTreeNode>> {
 	match &tokens[*ind].tok_type {
-		LexerTokenType::Dot => {
-			return parse_ast_value_dotacess(tokens, ind, original); // TODO: check if this is required or can be removed
-		},
-
 		LexerTokenType::MathOperator(_, _) => {
 			let o = &original?;
 			let k = Box::new(ASTTreeNode::clone(o.as_ref()));


### PR DESCRIPTION
Changelog:
- Moved dot chain handling from `parse_ast_value_post_l` to `parse_ast_value` to give priority to chain parsing against other things like comparators