### PR TITLE
optimization bug: Function call triggers unnecessary stack allocation, load and store

### DIFF
--- a/ir/src/conv/func.rs
+++ b/ir/src/conv/func.rs
@@ -118,7 +118,7 @@ pub fn parse_ir_function_call(ctx: &IRContext, f: &IRFunction, node: Box<ASTTree
 			return Ok(None);
 		}
 
-		return Ok(Some(IRValueRef::from_pointer(ret.unwrap())));
+		return Ok(Some(IRValueRef::from_val(ret.unwrap())));
 	}
 
 	return Err(PositionlessError::new("Cannot parse ir function call as the node is not a function call"))

--- a/ir/src/irstruct/funcs.rs
+++ b/ir/src/irstruct/funcs.rs
@@ -66,7 +66,7 @@ impl IRFunction {
 		return Ok(IRFunction::new(ctx, name, hash, func, ret_type, args));
 	}
 
-	pub fn call(&self, ctx: &IRContext, args: Vec<IRValueRef>, grab_return: bool) -> PositionlessResult<Option<IRPointer>> {
+	pub fn call(&self, ctx: &IRContext, args: Vec<IRValueRef>, grab_return: bool) -> PositionlessResult<Option<IRValue>> {
 		let mut inkwell_args = vec![];
 
 		for arg in args {
@@ -94,9 +94,7 @@ impl IRFunction {
 
 		let val = IRValue::new(OwnedValueEnum::new(&ctx.inkwell_ctx, val), return_type.clone());
 
-		let pointer = IRPointer::create(ctx, format!("function_ret_{}", self.name), return_type, Some(IRValueRef::from_val(val)))?;
-
-		return Ok(Some(pointer));
+		return Ok(Some(val));
 	}
 
 	/// Prepares the addition of the function body.


### PR DESCRIPTION
Changelog:
- Fixes a bug where a `alloc`, `store` and `load` are redundantly added for each function call.

After benchmarks, we can observe that Quickfall can be up to 20% faster on certain benchmarks such as the Fibonacci number computation one where it was able to beat C by almost 3 seconds when both languages use -O3 and about 10 seconds when no optimization is specified 