### PR TITLE
feat: Improved type parsing

### DIFF
--- a/compiler/ast/src/lib.rs
+++ b/compiler/ast/src/lib.rs
@@ -4,3 +4,4 @@
 
 pub mod tree;
 pub mod ctx;
+pub mod types;

--- a/compiler/ast/src/tree.rs
+++ b/compiler/ast/src/tree.rs
@@ -24,6 +24,8 @@ pub enum ASTTreeNodeKind {
     IntegerLit { val: i128, hash: u64 },
     StringLit(String),
 
+	ComplexType { t_hash: u64, size_definitions: Vec<usize>, extended_types: Vec<u64> },
+
 	OperatorBasedConditionMember { lval: Box<ASTTreeNode>, rval: Box<ASTTreeNode>, operator: ComparingOperator },
 	BooleanBasedConditionMember { val: Box<ASTTreeNode>, negate: bool },
 

--- a/compiler/ast/src/tree.rs
+++ b/compiler/ast/src/tree.rs
@@ -6,6 +6,8 @@ use compiler_utils::Position;
 use lexer::{toks::{comp::ComparingOperator, math::MathOperator}};
 use compiler_utils::hash::{TypeHash, WithHash};
 
+use crate::types::CompleteType;
+
 #[derive(Debug, PartialEq, Clone)]
 pub struct FunctionDeclarationArgument {
     pub name: WithHash<String>,
@@ -24,8 +26,6 @@ pub enum ASTTreeNodeKind {
     IntegerLit { val: i128, hash: u64 },
     StringLit(String),
 
-	ComplexType { t_hash: u64, size_definitions: Vec<usize>, extended_types: Vec<u64> },
-
 	OperatorBasedConditionMember { lval: Box<ASTTreeNode>, rval: Box<ASTTreeNode>, operator: ComparingOperator },
 	BooleanBasedConditionMember { val: Box<ASTTreeNode>, negate: bool },
 
@@ -34,9 +34,9 @@ pub enum ASTTreeNodeKind {
 	VariableReference(WithHash<String>),
 
 	StructLayoutDeclaration { name: WithHash<String>, layout: bool, members: Vec<Box<ASTTreeNode>> },
-	StructFieldMember { name: WithHash<String>, member_type: TypeHash },
+	StructFieldMember { name: WithHash<String>, member_type: CompleteType },
 
-    VarDeclaration { var_name: WithHash<String>, var_type: TypeHash, value: Option<Box<ASTTreeNode>> },
+    VarDeclaration { var_name: WithHash<String>, var_type: CompleteType, value: Option<Box<ASTTreeNode>> },
     VarValueChange { var: Box<ASTTreeNode>, value: Box<ASTTreeNode> },
 	VarIncrement { var: Box<ASTTreeNode>, increment_by: Option<Box<ASTTreeNode>> }, // Default is by 1
 
@@ -46,15 +46,15 @@ pub enum ASTTreeNodeKind {
 
 	ReturnStatement { val: Option<Box<ASTTreeNode>> },
 
-	StaticVariableDeclaration { name: WithHash<String>, var_type: TypeHash, val: Box<ASTTreeNode> },
+	StaticVariableDeclaration { name: WithHash<String>, var_type: CompleteType, val: Box<ASTTreeNode> },
 
 	WhileBlock { cond: Box<ASTTreeNode>, body: Vec<Box<ASTTreeNode>> },
 	ForBlock { initial_state: Box<ASTTreeNode>, cond: Box<ASTTreeNode>, increment: Box<ASTTreeNode>, body: Vec<Box<ASTTreeNode>> },
 
     FunctionCall { func: WithHash<String>, args: Vec<Box<ASTTreeNode>>  },
-    FunctionDeclaration { func_name: WithHash<String>, args: Vec<FunctionDeclarationArgument>, body: Vec<Box<ASTTreeNode>>, return_type: Option<TypeHash> },
+    FunctionDeclaration { func_name: WithHash<String>, args: Vec<FunctionDeclarationArgument>, body: Vec<Box<ASTTreeNode>>, return_type: Option<CompleteType> },
 
-	ShadowFunctionDeclaration { func_name: WithHash<String>, args: Vec<FunctionDeclarationArgument>, return_type: Option<TypeHash> },
+	ShadowFunctionDeclaration { func_name: WithHash<String>, args: Vec<FunctionDeclarationArgument>, return_type: Option<CompleteType> },
 
 	StructLRVariable { l: Box<ASTTreeNode>, r: Box<ASTTreeNode>,},
 	StructLRFunction { l: Box<ASTTreeNode>, r: Box<ASTTreeNode>, }

--- a/compiler/ast/src/types.rs
+++ b/compiler/ast/src/types.rs
@@ -1,0 +1,7 @@
+/// A parsed complete type information
+#[derive(Debug, PartialEq, Clone)]
+pub struct CompleteType {
+	pub base_type: u64, 
+	pub sizes: Vec<usize>,
+	pub types: Vec<u64>
+}

--- a/compiler/ast_parser/src/functions/mod.rs
+++ b/compiler/ast_parser/src/functions/mod.rs
@@ -5,7 +5,7 @@ use compiler_errors::errs::CompilerResult;
 use compiler_utils::hash::WithHash;
 use lexer::token::{LexerToken, LexerTokenType};
 
-use crate::{functions::arguments::parse_function_arguments, parser::parse_ast_node_in_body, value::parse_ast_value};
+use crate::{functions::arguments::parse_function_arguments, parser::parse_ast_node_in_body, types::parse_type, value::parse_ast_value};
 
 pub mod shadow;
 pub mod arguments;
@@ -27,7 +27,7 @@ pub fn parse_function_declaraction(tokens: &Vec<LexerToken>, ind: &mut usize) ->
 	let mut ret_type = None;
 
 	if tokens[*ind].is_keyword() {
-		ret_type = Some(tokens[*ind].expects_keyword()?.1);
+		ret_type = Some(parse_type(tokens, ind)?);
 		*ind += 1;
 	}
 

--- a/compiler/ast_parser/src/functions/shadow.rs
+++ b/compiler/ast_parser/src/functions/shadow.rs
@@ -5,7 +5,7 @@ use compiler_errors::errs::CompilerResult;
 use compiler_utils::hash::WithHash;
 use lexer::token::{LexerToken, LexerTokenType};
 
-use crate::functions::arguments::parse_function_arguments;
+use crate::{functions::arguments::parse_function_arguments, types::parse_type};
 
 pub fn parse_shadow_function_declaration(tokens: &Vec<LexerToken>, ind: &mut usize) -> CompilerResult<Box<ASTTreeNode>> {
 	let start = tokens[*ind].pos.clone();
@@ -24,7 +24,7 @@ pub fn parse_shadow_function_declaration(tokens: &Vec<LexerToken>, ind: &mut usi
 	let end;
 
 	if tokens[*ind].is_keyword() {
-		ret_type = Some(tokens[*ind].expects_keyword()?.1);
+		ret_type = Some(parse_type(tokens, ind)?);
 		*ind += 1;
 
 		end = tokens[*ind].get_end_pos().clone();

--- a/compiler/ast_parser/src/lib.rs
+++ b/compiler/ast_parser/src/lib.rs
@@ -16,6 +16,7 @@ pub mod structs;
 pub mod literals;
 pub mod control;
 pub mod variables;
+pub mod types;
 
 pub fn parse_ast_ctx(tokens: &Vec<LexerToken>) -> CompilerResult<ParserCtx> {
 	let mut ind = 0;

--- a/compiler/ast_parser/src/structs/members.rs
+++ b/compiler/ast_parser/src/structs/members.rs
@@ -4,10 +4,12 @@ use compiler_utils::hash::WithHash;
 
 use ast::tree::{ASTTreeNode, ASTTreeNodeKind};
 
+use crate::types::parse_type;
+
 /// Parses a struct/layout member (field)
 pub fn parse_types_field_member(tokens: &Vec<LexerToken>, ind: &mut usize) -> CompilerResult<Box<ASTTreeNode>> {
 	let start = tokens[*ind].pos.clone();
-	let type_name = tokens[*ind].expects_keyword()?;
+	let member_type = parse_type(tokens, ind)?;
 
 	*ind += 1;
 
@@ -17,5 +19,5 @@ pub fn parse_types_field_member(tokens: &Vec<LexerToken>, ind: &mut usize) -> Co
 
 	*ind += 1;
 
-	return Ok(Box::new(ASTTreeNode::new(ASTTreeNodeKind::StructFieldMember { name: WithHash::new(field_name.0), member_type: type_name.1 }, start, end)))
+	return Ok(Box::new(ASTTreeNode::new(ASTTreeNodeKind::StructFieldMember { name: WithHash::new(field_name.0), member_type }, start, end)))
 }

--- a/compiler/ast_parser/src/types.rs
+++ b/compiler/ast_parser/src/types.rs
@@ -1,15 +1,8 @@
 //! Parsing for type related features
 
-use ast::tree::{ASTTreeNode, ASTTreeNodeKind};
+use ast::{tree::{ASTTreeNode, ASTTreeNodeKind}, types::CompleteType};
 use compiler_errors::errs::CompilerResult;
 use lexer::token::{LexerToken, LexerTokenType};
-
-/// A parsed complete type information
-pub struct CompleteType {
-	pub base_type: u64, 
-	pub sizes: Vec<usize>,
-	pub types: Vec<u64>
-}
 
 pub fn parse_type(tokens: &Vec<LexerToken>, ind: &mut usize) -> CompilerResult<CompleteType> {
 	let base_type = tokens[*ind].expects_keyword()?;

--- a/compiler/ast_parser/src/types.rs
+++ b/compiler/ast_parser/src/types.rs
@@ -4,9 +4,15 @@ use ast::tree::{ASTTreeNode, ASTTreeNodeKind};
 use compiler_errors::errs::CompilerResult;
 use lexer::token::{LexerToken, LexerTokenType};
 
-pub fn parse_type(tokens: &Vec<LexerToken>, ind: &mut usize) -> CompilerResult<ASTTreeNode> {
+/// A parsed complete type information
+pub struct CompleteType {
+	pub base_type: u64, 
+	pub sizes: Vec<usize>,
+	pub types: Vec<u64>
+}
+
+pub fn parse_type(tokens: &Vec<LexerToken>, ind: &mut usize) -> CompilerResult<CompleteType> {
 	let base_type = tokens[*ind].expects_keyword()?;
-	let start = tokens[*ind].pos.clone();
 
 	let mut sizes: Vec<usize> = vec![];
 	let mut types: Vec<u64> = vec![];
@@ -36,7 +42,5 @@ pub fn parse_type(tokens: &Vec<LexerToken>, ind: &mut usize) -> CompilerResult<A
 		}
 	}
 
-	let end = tokens[*ind].get_end_pos();
-
-	return Ok(ASTTreeNode::new(ASTTreeNodeKind::ComplexType { t_hash: base_type.1, size_definitions: sizes, extended_types: types }, start, end))
+	return Ok(CompleteType { base_type: base_type.1, sizes, types })
 }

--- a/compiler/ast_parser/src/types.rs
+++ b/compiler/ast_parser/src/types.rs
@@ -1,0 +1,42 @@
+//! Parsing for type related features
+
+use ast::tree::{ASTTreeNode, ASTTreeNodeKind};
+use compiler_errors::errs::CompilerResult;
+use lexer::token::{LexerToken, LexerTokenType};
+
+pub fn parse_type(tokens: &Vec<LexerToken>, ind: &mut usize) -> CompilerResult<ASTTreeNode> {
+	let base_type = tokens[*ind].expects_keyword()?;
+	let start = tokens[*ind].pos.clone();
+
+	let mut sizes: Vec<usize> = vec![];
+	let mut types: Vec<u64> = vec![];
+
+	while tokens[*ind].tok_type == LexerTokenType::Dot {
+		*ind += 1;
+
+		let size_def = tokens[*ind].expects_int_lit()?.0 as usize;
+		sizes.push(size_def);
+	}
+
+	if tokens[*ind].tok_type == LexerTokenType::AngelBracketOpen {
+		*ind += 1;
+
+		loop {
+			let type_spec = tokens[*ind].expects_keyword()?;
+
+			types.push(type_spec.1);
+
+			*ind += 1;
+			
+			if tokens[*ind].tok_type == LexerTokenType::AngelBracketClose {
+				break;
+			}
+
+			tokens[*ind].expects(LexerTokenType::Comma)?;
+		}
+	}
+
+	let end = tokens[*ind].get_end_pos();
+
+	return Ok(ASTTreeNode::new(ASTTreeNodeKind::ComplexType { t_hash: base_type.1, size_definitions: sizes, extended_types: types }, start, end))
+}

--- a/compiler/ast_parser/src/variables/decl.rs
+++ b/compiler/ast_parser/src/variables/decl.rs
@@ -4,14 +4,14 @@ use compiler_utils::hash::WithHash;
 
 use ast::{tree::{ASTTreeNode, ASTTreeNodeKind}};
 
-use crate::value::parse_ast_value;
+use crate::{types::parse_type, value::parse_ast_value};
 
 pub fn parse_variable_declaration(tokens: &Vec<LexerToken>, ind: &mut usize) -> CompilerResult<Box<ASTTreeNode>> {
 	let start= tokens[*ind].pos.clone();
 
 	*ind += 1;
 
-	let type_name = tokens[*ind].expects_keyword()?;
+	let t = parse_type(tokens, ind)?;
 
 	*ind += 1;
 
@@ -31,5 +31,5 @@ pub fn parse_variable_declaration(tokens: &Vec<LexerToken>, ind: &mut usize) -> 
 		end = tokens[*ind - 1].get_end_pos().clone();
 	}
 
-	return Ok(Box::new(ASTTreeNode::new(ASTTreeNodeKind::VarDeclaration { var_name: WithHash::new(var_name.0), var_type: type_name.1, value: val }, start, end)));
+	return Ok(Box::new(ASTTreeNode::new(ASTTreeNodeKind::VarDeclaration { var_name: WithHash::new(var_name.0), var_type: t, value: val }, start, end)));
 }

--- a/compiler/ast_parser/src/variables/static_decl.rs
+++ b/compiler/ast_parser/src/variables/static_decl.rs
@@ -4,14 +4,14 @@ use compiler_utils::hash::WithHash;
 
 use ast::{tree::{ASTTreeNode, ASTTreeNodeKind}};
 
-use crate::value::parse_ast_value;
+use crate::{types::parse_type, value::parse_ast_value};
 
 pub fn parse_static_variable_declaration(tokens: &Vec<LexerToken>, ind: &mut usize) -> CompilerResult<Box<ASTTreeNode>> {
 	let start = tokens[*ind].pos.clone();
 
 	*ind += 1;
 
-	let var_type = tokens[*ind].expects_keyword()?;
+	let var_type = parse_type(tokens, ind)?;
 	*ind += 1;
 
 	let var_name = tokens[*ind].expects_keyword()?;
@@ -23,5 +23,5 @@ pub fn parse_static_variable_declaration(tokens: &Vec<LexerToken>, ind: &mut usi
 	let val = parse_ast_value(tokens, ind)?;
 	let end = val.end.clone();
 
-	return Ok(Box::new(ASTTreeNode::new(ASTTreeNodeKind::StaticVariableDeclaration { name: WithHash::new(var_name.0), val, var_type: var_type.1 }, start, end)))
+	return Ok(Box::new(ASTTreeNode::new(ASTTreeNodeKind::StaticVariableDeclaration { name: WithHash::new(var_name.0), val, var_type }, start, end)))
 }


### PR DESCRIPTION
Changelog:
- Improved type parsing to allow for size specifications for number types (#30 by @shishioko, #31 by @shishioko)

  Example syntax:
  ```
  var x.5.5 = 5; // Defines a signed fixed point integer with 5 * 2 bits!
  ```

- Improved type parsing to allow for type specifiers 
  
  Example syntax:
  ```
  var test<myType> theee;
  ```