### PR TITLE
[feat] Uniform struct declarations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ out
 out.*
 
 *.qf
+*.qfmir
 
 !examples/**.qf

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ target/
 
 out
 out.*
+
+*.qf
+
+!examples/**.qf

--- a/compiler/ast/src/tree.rs
+++ b/compiler/ast/src/tree.rs
@@ -44,7 +44,7 @@ pub enum ASTTreeNodeKind {
 	PointerGrab(Box<ASTTreeNode>),
 	ReferenceGrab(Box<ASTTreeNode>),
 
-	StructVariableInitializerValue { struct_type: ASTType, map: HashMap<SelfHash, Box<ASTTreeNode>> },
+	StructInitializer { map: HashMap<SelfHash, Box<ASTTreeNode>> },
 	ArrayVariableInitializerValueSameValue { size: usize, v: Box<ASTTreeNode> },
 	ArrayVariableInitializerValue { vals: Vec<Box<ASTTreeNode>> },
 
@@ -169,7 +169,7 @@ impl Display for ASTTreeNodeKind {
 			Self::VariableReference(_) => "variable reference",
 			Self::PointerGrab(_) => "pointer grabbing",
 			Self::ReferenceGrab(_) => "reference",
-			Self::StructVariableInitializerValue { .. } => "struct value initializer",
+			Self::StructInitializer { .. } => "struct value initializer",
 			Self::ArrayVariableInitializerValue { .. } | Self::ArrayVariableInitializerValueSameValue { .. } => "array value initializer",
 			Self::ArrayIndexAccess { .. } | Self::ArrayIndexModifiy { .. } => "index access",
 			Self::VarDeclaration { .. } => "variable declaration",

--- a/compiler/ast_parser/src/structs/val.rs
+++ b/compiler/ast_parser/src/structs/val.rs
@@ -18,7 +18,12 @@ pub fn parse_struct_initialize(tokens: &Vec<LexerToken>, ind: &mut usize) -> Dia
 		let field_name = tokens[*ind].expects_keyword()?;
 		*ind += 1;
 
+		tokens[*ind].expects(LexerTokenType::Collon)?;
+		*ind += 1;
+
+
 		let value = parse_ast_value(tokens, ind)?;
+
 
 		map.insert(SelfHash { hash: HashedString::new(field_name.0).hash }, value);
 

--- a/compiler/ast_parser/src/structs/val.rs
+++ b/compiler/ast_parser/src/structs/val.rs
@@ -5,15 +5,9 @@ use compiler_utils::hash::{HashedString, SelfHash};
 use diagnostics::DiagnosticResult;
 use lexer::token::{LexerToken, LexerTokenType};
 
-use crate::{types::parse_type, value::parse_ast_value};
+use crate::{value::parse_ast_value};
 
 pub fn parse_struct_initialize(tokens: &Vec<LexerToken>, ind: &mut usize) -> DiagnosticResult<Box<ASTTreeNode>> {
-	*ind += 1;
-
-	let t = parse_type(tokens, ind)?;
-
-	tokens[*ind].expects(LexerTokenType::BracketOpen)?;
-
 	let start = tokens[*ind].pos.clone();
 
 	*ind += 1;
@@ -40,5 +34,5 @@ pub fn parse_struct_initialize(tokens: &Vec<LexerToken>, ind: &mut usize) -> Dia
 
 	*ind += 1;
 
-	return Ok(Box::new(ASTTreeNode::new(ASTTreeNodeKind::StructVariableInitializerValue { struct_type: t, map }, start, tokens[*ind].get_end_pos())))
+	return Ok(Box::new(ASTTreeNode::new(ASTTreeNodeKind::StructInitializer { map }, start, tokens[*ind].get_end_pos())))
 }

--- a/compiler/ast_parser/src/types.rs
+++ b/compiler/ast_parser/src/types.rs
@@ -79,8 +79,6 @@ pub fn parse_type_generic(tokens: &Vec<LexerToken>, ind: &mut usize) -> Diagnost
 		specifier = None;
 	}
 
-	println!("{:#?}", specifier.clone());
-
 	let sizes = parse_type_size_specifiers(tokens, ind)?;
 	let types = parse_type_type_parameters(tokens, ind)?;
 

--- a/compiler/ast_parser/src/value.rs
+++ b/compiler/ast_parser/src/value.rs
@@ -177,7 +177,7 @@ pub fn parse_ast_value(tokens: &Vec<LexerToken>, ind: &mut usize) -> DiagnosticR
 			return Err(make_expected_simple_error(&tokens[*ind], &"function call or variable access".to_string(),&ast).into());
 		},
 
-		LexerTokenType::BracketOpen | LexerTokenType::ArrayOpen => {
+		LexerTokenType::ArrayOpen => {
 			return parse_ast_array_init(tokens, ind);
 		}
 

--- a/compiler/ast_parser/src/value.rs
+++ b/compiler/ast_parser/src/value.rs
@@ -194,7 +194,7 @@ pub fn parse_ast_value(tokens: &Vec<LexerToken>, ind: &mut usize) -> DiagnosticR
 			return parse_ast_value_post_l(tokens, ind, str, false);
 		},
 
-		LexerTokenType::New => {
+		LexerTokenType::BracketOpen => {
 			return parse_struct_initialize(tokens, ind);
 		}
 
@@ -221,34 +221,23 @@ pub fn parse_ast_value(tokens: &Vec<LexerToken>, ind: &mut usize) -> DiagnosticR
 
 pub fn parse_ast_array_init(tokens: &Vec<LexerToken>, ind: &mut usize) -> DiagnosticResult<Box<ASTTreeNode>> {
 	let start = tokens[*ind].pos.clone();
+	*ind += 1;
 
-	if tokens[*ind].tok_type == LexerTokenType::BracketOpen {
-		*ind += 1;
-
-		let int_lit = tokens[*ind].expects_int_lit()?;
-
-		*ind += 1;
-
-		tokens[*ind].expects(LexerTokenType::Dot)?;
-
-		*ind += 1;
-
+	if tokens[*ind + 1].tok_type == LexerTokenType::Comma {
 		let val = parse_ast_value(tokens, ind)?;
 
-		tokens[*ind].expects(LexerTokenType::BracketClose)?;
-
+		tokens[*ind].expects(LexerTokenType::Comma)?;
 		*ind += 1;
 
-		return Ok(Box::new(ASTTreeNode::new(ASTTreeNodeKind::ArrayVariableInitializerValueSameValue { size: int_lit.0 as usize, v: val }, start, tokens[*ind].get_end_pos())));
-	}
+		let count = tokens[*ind].expects_int_lit()?;
 
-	tokens[*ind].expects(LexerTokenType::ArrayOpen)?;
-	*ind += 1;
+		return Ok(Box::new(ASTTreeNode::new(ASTTreeNodeKind::ArrayVariableInitializerValueSameValue { size: count.0 as usize, v: val }, start, tokens[*ind].get_end_pos())))
+	}
 
 	let mut vals = vec![];
 
 	loop {
-		vals.push(parse_ast_value(tokens, ind)?);
+		let val = parse_ast_value(tokens, ind)?;
 
 		if tokens[*ind].tok_type == LexerTokenType::ArrayClose {
 			break;
@@ -256,11 +245,12 @@ pub fn parse_ast_array_init(tokens: &Vec<LexerToken>, ind: &mut usize) -> Diagno
 
 		tokens[*ind].expects(LexerTokenType::Comma)?;
 		*ind += 1;
+
+		vals.push(val);
 	}
 
-	*ind += 1;
-
 	return Ok(Box::new(ASTTreeNode::new(ASTTreeNodeKind::ArrayVariableInitializerValue { vals }, start, tokens[*ind].get_end_pos())))
+
 }
 
 pub fn parse_ast_pointer(tokens: &Vec<LexerToken>, ind: &mut usize) -> DiagnosticResult<Box<ASTTreeNode>> {

--- a/compiler/astoir_hir/src/ctx.rs
+++ b/compiler/astoir_hir/src/ctx.rs
@@ -207,7 +207,7 @@ impl HIRBranchedContext {
 	pub fn is_eligible_for_ssa(&self, ind: usize) -> bool {
 		let var = &self.variables[ind];
 
-		return !var.requires_address && var.mutation_count <= 1 && !var.variable_type.can_use_index_access()
+		return !var.requires_address && var.mutation_count <= 1 && !var.variable_type.can_use_index_access() && false
 	}
 	
 }

--- a/compiler/astoir_hir/src/lib.rs
+++ b/compiler/astoir_hir/src/lib.rs
@@ -4,3 +4,4 @@
 pub mod ctx;
 pub mod nodes;
 pub mod structs;
+pub mod resolve;

--- a/compiler/astoir_hir/src/nodes.rs
+++ b/compiler/astoir_hir/src/nodes.rs
@@ -71,7 +71,9 @@ pub enum HIRNodeKind {
 	ArrayIndexAccess { val: Box<HIRNode>, index: Box<HIRNode> },
 	ArrayIndexModify { array: Box<HIRNode>, index: Box<HIRNode>, new_val : Box<HIRNode> },
 
-	StructVariableInitializerValue { t: Type, fields: Vec<Box<HIRNode>> },
+	/// Before transmutation
+	StructInitializer { fields: Vec<Box<HIRNode>> },
+	StructInitializerTyped { t: Type, fields: Vec<Box<HIRNode>> },
 
 	FunctionDeclaration { func_name: usize, arguments: Vec<(u64, Type)>, return_type: Option<Type>, body: Vec<Box<HIRNode>>, ctx: HIRBranchedContext, requires_this: bool },
 	
@@ -181,6 +183,14 @@ impl HIRNode {
 		return Err(make_diff_type_val(origin, &t.faulty_lowering_generic(&context.type_storage), &self.get_node_type(context, curr_ctx).unwrap().faulty_lowering_generic(&context.type_storage)).into())
 	}	
 
+	pub fn is_intederminately_typed(&self) -> bool {
+		match self.kind {
+			HIRNodeKind::StructInitializer { .. } => true,
+
+			_ => false
+		}
+	}
+
 	pub fn get_node_type(&self, context: &HIRContext, curr_ctx: &HIRBranchedContext) -> Option<Type> {
 		match &self.kind {
 			HIRNodeKind::VariableReference { index, is_static } => {
@@ -241,9 +251,7 @@ impl HIRNode {
 				return Some(Type::Generic(RawType::Boolean, vec![], vec![]))
 			},
 
-			HIRNodeKind::StructVariableInitializerValue { t, fields: _ } => {
-				return Some(t.clone())
-			}
+			HIRNodeKind::StructInitializerTyped { t, fields: _ } => Some(t.clone()),
 
 			HIRNodeKind::FunctionCall { func_name, arguments: _ } => {
 				let f = context.functions.vals[*func_name].0.clone();

--- a/compiler/astoir_hir/src/nodes.rs
+++ b/compiler/astoir_hir/src/nodes.rs
@@ -7,7 +7,7 @@ use compiler_utils::{Position, hash::SelfHash};
 use diagnostics::{DiagnosticSpanOrigin, builders::{make_diff_type, make_diff_type_val}, diagnostic::{Diagnostic, Span, SpanKind, SpanPosition}, unsure_panic};
 use lexer::toks::{comp::ComparingOperator, math::MathOperator};
 
-use crate::{ctx::{HIRBranchedContext, HIRContext}, structs::{HIRIfBranch, StructLRUStep}};
+use crate::{ctx::{HIRBranchedContext, HIRContext}, resolve::resolve_to_type, structs::{HIRIfBranch, StructLRUStep}};
 
 #[derive(Debug, Clone)]
 pub struct HIRNode {	
@@ -137,13 +137,7 @@ impl HIRNode {
 	
 	pub fn use_as<K: DiagnosticSpanOrigin>(&self, context: &HIRContext, curr_ctx: &HIRBranchedContext, t: Type, origin: &K, var_origin: Option<&K>) -> Result<HIRNode, ()> {
 		if self.is_intederminately_typed() {
-			match &self.kind {
-				HIRNodeKind::StructInitializer { fields } => {
-					
-				},	
-
-				_ => unsure_panic!("is_intederminately_typed returned true but conversion implementation isn't implemented for said HIRNode")
-			}
+			return Ok(*resolve_to_type(Box::new(self.clone()), t, context, curr_ctx, origin)?);
 		}
 
 		let self_type = match self.get_node_type(context, curr_ctx) {

--- a/compiler/astoir_hir/src/nodes.rs
+++ b/compiler/astoir_hir/src/nodes.rs
@@ -1,7 +1,9 @@
 //! The nodes inside of the AstoIR HIR. 
 
+use std::collections::HashMap;
+
 use compiler_typing::{raw::RawType, references::TypeReference, storage::{BOOLEAN_TYPE, STATIC_STR}, structs::RawStructTypeContainer, transmutation::array::can_transmute_inner, tree::Type};
-use compiler_utils::Position;
+use compiler_utils::{Position, hash::SelfHash};
 use diagnostics::{DiagnosticSpanOrigin, builders::{make_diff_type, make_diff_type_val}, diagnostic::{Diagnostic, Span, SpanKind, SpanPosition}, unsure_panic};
 use lexer::toks::{comp::ComparingOperator, math::MathOperator};
 
@@ -72,7 +74,7 @@ pub enum HIRNodeKind {
 	ArrayIndexModify { array: Box<HIRNode>, index: Box<HIRNode>, new_val : Box<HIRNode> },
 
 	/// Before transmutation
-	StructInitializer { fields: Vec<Box<HIRNode>> },
+	StructInitializer { fields: HashMap<SelfHash, Box<HIRNode>> },
 	StructInitializerTyped { t: Type, fields: Vec<Box<HIRNode>> },
 
 	FunctionDeclaration { func_name: usize, arguments: Vec<(u64, Type)>, return_type: Option<Type>, body: Vec<Box<HIRNode>>, ctx: HIRBranchedContext, requires_this: bool },
@@ -134,6 +136,16 @@ impl HIRNode {
 	}
 	
 	pub fn use_as<K: DiagnosticSpanOrigin>(&self, context: &HIRContext, curr_ctx: &HIRBranchedContext, t: Type, origin: &K, var_origin: Option<&K>) -> Result<HIRNode, ()> {
+		if self.is_intederminately_typed() {
+			match &self.kind {
+				HIRNodeKind::StructInitializer { fields } => {
+					
+				},	
+
+				_ => unsure_panic!("is_intederminately_typed returned true but conversion implementation isn't implemented for said HIRNode")
+			}
+		}
+
 		let self_type = match self.get_node_type(context, curr_ctx) {
 			Some(v) => v,
 			_ => panic!("Tried using a typeless node in use_as: {:#?}", self)

--- a/compiler/astoir_hir/src/nodes.rs
+++ b/compiler/astoir_hir/src/nodes.rs
@@ -152,8 +152,6 @@ impl HIRNode {
 		}
 
 		if self_type.can_transmute(&t, &context.type_storage) {
-			println!("Can transmute {:#?} -> {:#?}", t, self);
-
 			match &self.kind {
 				HIRNodeKind::IntegerLiteral { value, int_type: _ } => {
 					return Ok(self.with(HIRNodeKind::IntegerLiteral { value: *value, int_type: t }));

--- a/compiler/astoir_hir/src/nodes.rs
+++ b/compiler/astoir_hir/src/nodes.rs
@@ -64,6 +64,8 @@ pub enum HIRNodeKind {
 
 	StructLRU { steps: Vec<StructLRUStep>, last: Type },
 
+	EnumParentCast { val: Box<HIRNode>, parent: Type },
+
 	StructDeclaration { type_name: usize, container: RawStructTypeContainer, layout: bool },
 	StructFunctionDeclaration { func_name: usize, arguments: Vec<(u64, TypeReference)>, return_type: Option<TypeReference>, body: Vec<Box<HIRNode>>, ctx: HIRBranchedContext, requires_this: bool },
 	
@@ -137,7 +139,7 @@ impl HIRNode {
 	
 	pub fn use_as<K: DiagnosticSpanOrigin>(&self, context: &HIRContext, curr_ctx: &HIRBranchedContext, t: Type, origin: &K, var_origin: Option<&K>) -> Result<HIRNode, ()> {
 		if self.is_intederminately_typed() {
-			return Ok(*resolve_to_type(Box::new(self.clone()), t, context, curr_ctx, origin)?);
+			return Ok(resolve_to_type(Box::new(self.clone()), t.clone(), context, curr_ctx, origin)?.use_as(context, curr_ctx, t, origin, var_origin)?);
 		}
 
 		let self_type = match self.get_node_type(context, curr_ctx) {
@@ -150,11 +152,13 @@ impl HIRNode {
 		}
 
 		if self_type.can_transmute(&t, &context.type_storage) {
+			println!("Can transmute {:#?} -> {:#?}", t, self);
+
 			match &self.kind {
 				HIRNodeKind::IntegerLiteral { value, int_type: _ } => {
 					return Ok(self.with(HIRNodeKind::IntegerLiteral { value: *value, int_type: t }));
 				},
-
+				
 				HIRNodeKind::ArrayVariableInitializerValue { vals } => {
 					if can_transmute_inner(&self_type, &t, &context.type_storage) {
 						let mut new_vals = vec![];
@@ -234,12 +238,7 @@ impl HIRNode {
 			},
 
 			HIRNodeKind::StringLiteral { value: _ } => {
-				let ind = match context.type_storage.types.get_index(STATIC_STR) {
-					Some(v) => v,
-					None => return None
-				};
-
-				return Some(Type::Generic(RawType::Boolean, vec![], vec![]))
+				return Some(Type::Generic(RawType::StaticString, vec![], vec![]))
 			},
 
 			HIRNodeKind::ArrayVariableInitializerValue { vals } => return Some(Type::Array(vals.len(), Box::new(vals[0].get_node_type(context, curr_ctx).unwrap()))),

--- a/compiler/astoir_hir/src/resolve.rs
+++ b/compiler/astoir_hir/src/resolve.rs
@@ -1,0 +1,41 @@
+//! Used to resolve incomplete HIR nodes like initializers
+
+use compiler_typing::tree::Type;
+use compiler_utils::hash::SelfHash;
+use diagnostics::{DiagnosticResult, DiagnosticSpanOrigin, builders::{make_req_type_kind, make_struct_init_missing_field}};
+
+use crate::{ctx::{HIRBranchedContext, HIRContext}, nodes::{HIRNode, HIRNodeKind}};
+
+/// Resolves incomplete HIR nodes into complete nodes
+pub fn resolve_to_type<K: DiagnosticSpanOrigin>(node: Box<HIRNode>, destination: Type, context: &HIRContext, curr_ctx: &HIRBranchedContext, origin: &K) -> DiagnosticResult<Box<HIRNode>> {
+	match node.kind {
+		HIRNodeKind::StructInitializer { fields } => {
+			let generic = destination.as_generic_lowered_safe(origin)?;
+			let mut new_fields = vec![];
+
+			if !generic.is_field_based() {
+				return Err(make_req_type_kind(origin, &"field-having".to_string()).into())
+			}
+
+			for field in destination.get_fields(&context.type_storage) {
+				let identity = SelfHash { hash: field };
+
+				if !fields.contains_key(&identity) {
+					return Err(make_struct_init_missing_field(origin, &destination, &field).into())
+				}
+
+				let val = fields[&identity].clone();
+
+				let field_data = destination.get_field(&context.type_storage, field)?.1.resolve(&destination);
+
+				let val = Box::new(val.use_as(context, curr_ctx, field_data, origin, None)?);
+
+				new_fields.push(val);
+			}
+
+			return Ok(Box::new(HIRNode::new(HIRNodeKind::StructInitializerTyped { t: destination, fields: new_fields }, &node.start, &node.end)))
+		},
+
+		_ => panic!("Invalid node")
+	}
+} 

--- a/compiler/astoir_hir/src/resolve.rs
+++ b/compiler/astoir_hir/src/resolve.rs
@@ -10,7 +10,7 @@ use crate::{ctx::{HIRBranchedContext, HIRContext}, nodes::{HIRNode, HIRNodeKind}
 pub fn resolve_to_type<K: DiagnosticSpanOrigin>(node: Box<HIRNode>, destination: Type, context: &HIRContext, curr_ctx: &HIRBranchedContext, origin: &K) -> DiagnosticResult<Box<HIRNode>> {
 	match node.kind {
 		HIRNodeKind::StructInitializer { fields } => {
-			let generic = destination.as_generic_lowered_safe(origin)?;
+			let generic = destination.as_generic_safe(origin)?;
 			let mut new_fields = vec![];
 
 			if !generic.is_field_based() {

--- a/compiler/astoir_hir_lowering/src/structs.rs
+++ b/compiler/astoir_hir_lowering/src/structs.rs
@@ -89,7 +89,7 @@ pub fn lower_ast_struct_declaration(context: &mut HIRContext, node: Box<ASTTreeN
 }
 
 pub fn lower_ast_struct_initializer(context: &mut HIRContext, curr_ctx: &mut HIRBranchedContext, node: Box<ASTTreeNode>) -> DiagnosticResult<Box<HIRNode>> {
-	if let ASTTreeNodeKind::StructVariableInitializerValue { struct_type, map } = node.kind.clone() {
+	if let ASTTreeNodeKind::StructInitializer { map } = node.kind.clone() {
 		let raw = match context.type_storage.get_type(HashedString::new(struct_type.get_generic_name()).hash) {
 			Ok(v) => Type::GenericLowered(v),
 			Err(_) => return Err(make_cannot_find_type(&*node, &struct_type.get_generic_name()).into())

--- a/compiler/astoir_hir_lowering/src/structs.rs
+++ b/compiler/astoir_hir_lowering/src/structs.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use ast::tree::{ASTTreeNode, ASTTreeNodeKind};
 use astoir_hir::{ctx::{HIRBranchedContext, HIRContext}, nodes::{HIRNode, HIRNodeKind}, structs::HIRStructContainer};
 use compiler_typing::{raw::RawType, structs::RawStructTypeContainer, tree::Type};
@@ -90,39 +92,13 @@ pub fn lower_ast_struct_declaration(context: &mut HIRContext, node: Box<ASTTreeN
 
 pub fn lower_ast_struct_initializer(context: &mut HIRContext, curr_ctx: &mut HIRBranchedContext, node: Box<ASTTreeNode>) -> DiagnosticResult<Box<HIRNode>> {
 	if let ASTTreeNodeKind::StructInitializer { map } = node.kind.clone() {
-		let raw = match context.type_storage.get_type(HashedString::new(struct_type.get_generic_name()).hash) {
-			Ok(v) => Type::GenericLowered(v),
-			Err(_) => return Err(make_cannot_find_type(&*node, &struct_type.get_generic_name()).into())
-		};
+		let mut new_map = HashMap::new();
 
-		let hir_type = lower_ast_type(context, struct_type, &*node)?;
-
-		let fields = raw.get_fields(&context.type_storage);
-
-		let mut vals = vec![];
-
-		for field in fields {
-			let id = SelfHash { hash: field };
-
-			if !map.contains_key(&id) {
-				return Err(make_struct_init_missing_field(&*node, &hir_type, &field).into())
-			}
-
-			let field = match raw.get_field(&context.type_storage, field) {
-				Ok(v) => v,
-				Err(_) => return Err(make_struct_missing_field(&*node, &hir_type, &id.hash).into())
-			};
-
-			let tt = field.1.resolve(&hir_type);
-
-			let val = lower_ast_value(context, curr_ctx, map[&id].clone())?;
-
-			let val = Box::new(val.use_as(context, curr_ctx, tt.clone(), &*node, None)?);
-
-			vals.push(val)
+		for (k, v) in map {
+			new_map.insert(k, lower_ast_value(context, curr_ctx, v)?);
 		}
 
-		return Ok(Box::new(HIRNode::new(HIRNodeKind::StructVariableInitializerValue { t: hir_type, fields: vals }, &node.start, &node.end)))
+		return Ok(Box::new(HIRNode::new(HIRNodeKind::StructInitializer { fields: new_map }, &node.start, &node.end)))
 	}
 
 	panic!("Invalid node type")

--- a/compiler/astoir_hir_lowering/src/unwraps.rs
+++ b/compiler/astoir_hir_lowering/src/unwraps.rs
@@ -2,11 +2,11 @@ use ast::tree::{ASTTreeNode, ASTTreeNodeKind};
 use astoir_hir::{ctx::{HIRBranchedContext, HIRContext}, nodes::{HIRNode, HIRNodeKind}};
 use diagnostics::DiagnosticResult;
 
-use crate::{types::lower_ast_type, values::lower_ast_value};
+use crate::{types::lower_ast_type, values::lower_ast_value, var::lower_ast_variable_reference};
 
 pub fn lower_ast_condition_unwrap(context: &mut HIRContext, curr_ctx: &mut HIRBranchedContext, node: Box<ASTTreeNode>) -> DiagnosticResult<Box<HIRNode>> {
 	if let ASTTreeNodeKind::UnwrapCondition { original, target_type, unsafe_unwrap, target_var } = node.clone().kind {
-		let original = lower_ast_value(context, curr_ctx, original)?;
+		let original = lower_ast_variable_reference(context, curr_ctx, original, true)?;
 		let target_type = lower_ast_type(context, target_type, &*node)?;
 		
 		if target_var.is_none() {

--- a/compiler/astoir_hir_lowering/src/values.rs
+++ b/compiler/astoir_hir_lowering/src/values.rs
@@ -146,7 +146,7 @@ pub fn lower_ast_value(context: &mut HIRContext, curr_ctx: &mut HIRBranchedConte
 			return lower_ast_array_init(context, curr_ctx, node)
 		}
 
-		ASTTreeNodeKind::StructVariableInitializerValue { .. } => {
+		ASTTreeNodeKind::StructInitializer { .. } => {
 			return lower_ast_struct_initializer(context, curr_ctx, node)
 		}
 

--- a/compiler/astoir_mir/src/builder.rs
+++ b/compiler/astoir_mir/src/builder.rs
@@ -1,7 +1,7 @@
 //! Utility functions to build instructions and more
 
-use compiler_typing::{raw::RawType, tree::Type};
-use diagnostics::{DiagnosticResult, diagnostic::Diagnostic, unsure_panic};
+use compiler_typing::{SizedType, raw::RawType, storage::TypeStorage, tree::Type};
+use diagnostics::{DiagnosticResult, MaybeDiagnostic, diagnostic::Diagnostic, unsure_panic};
 
 use crate::{blocks::{hints::MIRValueHint, refer::MIRBlockReference}, ctx::MIRContext, insts::MIRInstruction, vals::{arrays::MIRArrayValue, base::BaseMIRValue, float::MIRFloatValue, int::MIRIntValue, ptr::MIRPointerValue, structs::MIRStructValue}};
 
@@ -23,18 +23,22 @@ pub fn build_load(ctx: &mut MIRContext, ptr: MIRPointerValue) -> DiagnosticResul
 	return Ok(res);
 }
 
-pub fn build_store(ctx: &mut MIRContext, ptr: MIRPointerValue, val: BaseMIRValue) -> DiagnosticResult<bool> {
+pub fn build_store(ctx: &mut MIRContext, storage: &TypeStorage, ptr: MIRPointerValue, val: BaseMIRValue) -> DiagnosticResult<()> {
 	let base: BaseMIRValue = ptr.clone().into();
 
 	let hint = ctx.ssa_hints.get_hint(base.get_ssa_index()).get_type();
 
 	if !hint.get_maybe_containing_type().is_truly_eq(&val.vtype) && !hint.is_ptr() {
+		if hint.get_maybe_containing_type().get_generic(storage).is_enum_parent() && val.vtype.get_generic(storage).is_enum_child() {
+			return build_store_fallback(ctx, ptr, val.clone(), storage)
+		}
+
 		unsure_panic!("cannot put this value onto this pointer since it's not the type");
 	}
 
 	ctx.append_inst(MIRInstruction::Store { variable: ptr, value: val });
 
-	return Ok(true) 
+	return Ok(()) 
 }
 
 pub fn build_downcast_int(ctx: &mut MIRContext, val: MIRIntValue, size: usize) -> DiagnosticResult<MIRIntValue> {
@@ -462,3 +466,26 @@ pub fn build_ir_cast(ctx: &mut MIRContext, val: BaseMIRValue, to: Type) -> Diagn
 pub fn build_memory_copy_unsafe(ctx: &mut MIRContext, src: MIRPointerValue, dest: MIRPointerValue, size: usize) {
 	ctx.append_inst(MIRInstruction::MemoryCopy { src, dest, sz: size });
 }
+
+/// Fallback to whenever store fails since the type isn't valid. Allows to use unsafe memory copy for enums
+/// # Behvior
+/// If `src` is actually a pointer, simply uses the `unsmemcopy` instruction to copy the memory from `src` to `dest`. 
+/// If not, it first creates a pointer for `src`, storing the value inside and then using the `unsmemcopy` instruction.
+pub fn build_store_fallback(ctx: &mut MIRContext, dest: MIRPointerValue, src: BaseMIRValue, storage: &TypeStorage) -> MaybeDiagnostic {
+	let sz = src.vtype.get_size(&src.vtype, false, storage);
+
+	if src.can_be_pointer() {
+		let src = src.as_ptr()?;
+	
+		ctx.append_inst(MIRInstruction::MemoryCopy { src, dest, sz: sz});
+		return Ok(())
+	}	
+
+	let ptr = build_stack_alloc(ctx, sz, src.vtype.clone())?;
+
+	build_store(ctx, storage, ptr.clone(), src)?;
+
+	ctx.append_inst(MIRInstruction::MemoryCopy { src: ptr, dest, sz });
+
+	Ok(())
+}	

--- a/compiler/astoir_mir/src/builder.rs
+++ b/compiler/astoir_mir/src/builder.rs
@@ -1,7 +1,7 @@
 //! Utility functions to build instructions and more
 
 use compiler_typing::{raw::RawType, tree::Type};
-use diagnostics::{DiagnosticResult, unsure_panic};
+use diagnostics::{DiagnosticResult, diagnostic::Diagnostic, unsure_panic};
 
 use crate::{blocks::{hints::MIRValueHint, refer::MIRBlockReference}, ctx::MIRContext, insts::MIRInstruction, vals::{arrays::MIRArrayValue, base::BaseMIRValue, float::MIRFloatValue, int::MIRIntValue, ptr::MIRPointerValue, structs::MIRStructValue}};
 
@@ -457,4 +457,8 @@ pub fn build_ir_cast(ctx: &mut MIRContext, val: BaseMIRValue, to: Type) -> Diagn
 	let res = ctx.append_inst(MIRInstruction::IRCast { val, to }).get()?;
 
 	return Ok(res);
+}
+
+pub fn build_memory_copy_unsafe(ctx: &mut MIRContext, src: MIRPointerValue, dest: MIRPointerValue, size: usize) {
+	ctx.append_inst(MIRInstruction::MemoryCopy { src, dest, sz: size });
 }

--- a/compiler/astoir_mir/src/builder.rs
+++ b/compiler/astoir_mir/src/builder.rs
@@ -434,6 +434,7 @@ pub fn build_call(ctx: &mut MIRContext, func: usize, ind: usize, args: Vec<BaseM
 
 	for(arg, t) in args.iter().zip(func.arguments.iter()) {
 		if !arg.vtype.is_truly_eq(t) {
+			println!("{:#?} -> {:#?}", arg.vtype, t);
 			unsure_panic!("invalid function argument types!");
 		}
 	}

--- a/compiler/astoir_mir/src/insts/mod.rs
+++ b/compiler/astoir_mir/src/insts/mod.rs
@@ -84,6 +84,9 @@ pub enum MIRInstruction {
 
 	FuncArgumentGrab { ind: usize, argtype: Type },
 
+	// Memory utils
+	MemoryCopy { src: MIRPointerValue, dest: MIRPointerValue, sz: usize },
+
 	/// Indicates to the IR processor that this given value's era is finished and thus we drop the value
 	MarkerEraDrop { value: BaseMIRValue },
 
@@ -94,7 +97,7 @@ pub enum MIRInstruction {
 impl MIRInstruction {
 	pub fn has_return(&self, ctx: &MIRContext) -> bool {
 		match self {
-			Self::MarkerEraDrop { .. } | Self::UnconditionalBranch { .. } | Self::ConditionalBranch { .. } | Self::Return { .. } | Self::Store { .. } => {
+			Self::MarkerEraDrop { .. } | Self::UnconditionalBranch { .. } | Self::ConditionalBranch { .. } | Self::Return { .. } | Self::Store { .. } | Self::MemoryCopy {.. } => {
 				return false;
 			},
 
@@ -209,6 +212,8 @@ impl Display for MIRInstruction {
 			Self::Load { value } => writeln!(f, "load {}", value)?,
 			Self::Store { variable, value } => writeln!(f, "store d{} s{}", variable, value)?,
 
+			Self::MemoryCopy { src, dest, sz } => writeln!(f, "unsmemcopy s{} d{} {}b", src, dest, sz)?,
+
 			Self::DowncastInteger { val, size } => writeln!(f, "dintcast {} {}", val, size)?,
 			Self::DowncastFloat { val, size } => writeln!(f, "dfcast {} {}", val, size)?,
 			Self::UpcastInteger { val, size } => writeln!(f, "uintcast {} {}", val, size)?,
@@ -254,18 +259,18 @@ impl Display for MIRInstruction {
 			Self::StaticStringConstant { raw } => writeln!(f, "conststr {}", raw)?,
 
 			Self::StructInitializerConstant { struct_type: _, values } => {
-				writeln!(f, "conststructinitrz ")?;
+				writeln!(f, "conststructinitrz")?;
 			
 				for v in values {
-					write!(f, "{}", v)?;
+					write!(f, " {}", v)?;
 				}
 			},
 
 			Self::ArrayInitializerConstant { values } => {
-				writeln!(f, "constarrinitrz ")?;
+				writeln!(f, "constarrinitrz")?;
 
 				for v in values {
-					write!(f, "{}", v)?;
+					write!(f, " {}", v)?;
 				}
 			},
 

--- a/compiler/astoir_mir/src/vals/base.rs
+++ b/compiler/astoir_mir/src/vals/base.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use compiler_typing::tree::Type;
+use compiler_typing::{raw::RawType, tree::Type};
 use diagnostics::DiagnosticResult;
 
 use crate::vals::{arrays::MIRArrayValue, float::MIRFloatValue, int::MIRIntValue, ptr::MIRPointerValue, structs::MIRStructValue};
@@ -35,6 +35,10 @@ impl BaseMIRValue {
 
 	pub fn as_array(&self) -> DiagnosticResult<MIRArrayValue> {
 		return Ok(MIRArrayValue::new(self.clone())?);
+	}
+
+	pub fn can_be_pointer(&self) -> bool {
+		return self.vtype.is_technically_pointer() || self.vtype.is_array() || self.vtype.as_generic_lowered() == RawType::Pointer
 	}
 
 	pub fn get_ssa_index(&self) -> usize {

--- a/compiler/astoir_mir/src/vals/refer.rs
+++ b/compiler/astoir_mir/src/vals/refer.rs
@@ -1,3 +1,4 @@
+use compiler_typing::storage::TypeStorage;
 use diagnostics::{DiagnosticResult, builders::make_invalid_assign_diff_type_ir, unsure_panic};
 
 use crate::{blocks::refer::MIRBlockReference, builder::{build_load, build_store}, ctx::MIRContext, vals::{base::BaseMIRValue, ptr::{MIRPointerValue}}};
@@ -39,7 +40,7 @@ impl MIRVariableReference {
 		}
 	}
 
-	pub fn write(&self, block: MIRBlockReference, ctx: &mut MIRContext, val: BaseMIRValue) -> DiagnosticResult<bool> {
+	pub fn write(&self, block: MIRBlockReference, ctx: &mut MIRContext, val: BaseMIRValue, storage: &TypeStorage) -> DiagnosticResult<bool> {
 		if self.is_pointer_ref() {
 			let mut ptr_ref = self.as_pointer_ref()?;	
 			let hint = ctx.ssa_hints.get_hint(BaseMIRValue::from(ptr_ref.clone().into()).get_ssa_index());
@@ -48,7 +49,7 @@ impl MIRVariableReference {
 				ptr_ref = build_load(ctx, ptr_ref)?.as_ptr()?;
 			}
 
-			build_store(ctx, ptr_ref, val)?;
+			build_store(ctx, storage, ptr_ref, val)?;
 
 			return Ok(true);
 		}

--- a/compiler/astoir_mir_lowering/src/arrays.rs
+++ b/compiler/astoir_mir_lowering/src/arrays.rs
@@ -30,7 +30,7 @@ pub fn lower_hir_array_modify(block: MIRBlockReference, node: Box<HIRNode>, ctx:
 
 		let index_pointer = build_index_pointer(&mut ctx.mir_ctx, array, index)?;
 
-		build_store(&mut ctx.mir_ctx, index_pointer, val)?;
+		build_store(&mut ctx.mir_ctx,  &ctx.hir_ctx.type_storage, index_pointer, val)?;
 
 		return Ok(true);
 	}

--- a/compiler/astoir_mir_lowering/src/casts.rs
+++ b/compiler/astoir_mir_lowering/src/casts.rs
@@ -1,0 +1,33 @@
+use astoir_hir::nodes::{HIRNode, HIRNodeKind};
+use astoir_mir::{blocks::{hints::MIRValueHint, refer::MIRBlockReference}, vals::base::BaseMIRValue};
+use diagnostics::DiagnosticResult;
+
+use crate::{MIRLoweringContext, lower_hir_type, values::lower_hir_value};
+
+pub fn lower_cast(block: MIRBlockReference, node: Box<HIRNode>, ctx: &mut MIRLoweringContext) -> DiagnosticResult<BaseMIRValue> {
+	if let HIRNodeKind::CastValue { intentional, value, old_type, new_type } = node.kind.clone() {
+		let value = lower_hir_value(block, value, ctx)?;
+		let old_type = lower_hir_type(ctx, old_type)?;
+
+		println!("Old: {:#?}", old_type);
+
+		let new_type = lower_hir_type(ctx, new_type)?;
+		println!("New: {:#?}", new_type);
+
+		if old_type.get_generic(&ctx.hir_ctx.type_storage).is_enum_child() && new_type.get_generic(&ctx.hir_ctx.type_storage).is_enum_parent() {
+			// Hacky way to make it a parent enum
+
+			match ctx.mir_ctx.ssa_hints.vec[value.get_ssa_index()] {
+				MIRValueHint::Pointer(_) => ctx.mir_ctx.ssa_hints.vec[value.get_ssa_index()] = MIRValueHint::Pointer(new_type),
+				MIRValueHint::Value(_) => ctx.mir_ctx.ssa_hints.vec[value.get_ssa_index()] = MIRValueHint::Value(new_type),
+				_ => panic!("constant enum cast")
+			}
+
+			return Ok(value);
+		}
+
+		panic!("Bad castt {:#?} -> {:#?}", old_type, new_type);
+	}
+
+	panic!("Invalid node or cast!")
+}

--- a/compiler/astoir_mir_lowering/src/casts.rs
+++ b/compiler/astoir_mir_lowering/src/casts.rs
@@ -15,8 +15,6 @@ pub fn lower_cast(block: MIRBlockReference, node: Box<HIRNode>, ctx: &mut MIRLow
 		println!("New: {:#?}", new_type);
 
 		if old_type.get_generic(&ctx.hir_ctx.type_storage).is_enum_child() && new_type.get_generic(&ctx.hir_ctx.type_storage).is_enum_parent() {
-			// Hacky way to make it a parent enum
-
 			match ctx.mir_ctx.ssa_hints.vec[value.get_ssa_index()] {
 				MIRValueHint::Pointer(_) => ctx.mir_ctx.ssa_hints.vec[value.get_ssa_index()] = MIRValueHint::Pointer(new_type),
 				MIRValueHint::Value(_) => ctx.mir_ctx.ssa_hints.vec[value.get_ssa_index()] = MIRValueHint::Value(new_type),

--- a/compiler/astoir_mir_lowering/src/casts.rs
+++ b/compiler/astoir_mir_lowering/src/casts.rs
@@ -9,10 +9,7 @@ pub fn lower_cast(block: MIRBlockReference, node: Box<HIRNode>, ctx: &mut MIRLow
 		let value = lower_hir_value(block, value, ctx)?;
 		let old_type = lower_hir_type(ctx, old_type)?;
 
-		println!("Old: {:#?}", old_type);
-
 		let new_type = lower_hir_type(ctx, new_type)?;
-		println!("New: {:#?}", new_type);
 
 		if old_type.get_generic(&ctx.hir_ctx.type_storage).is_enum_child() && new_type.get_generic(&ctx.hir_ctx.type_storage).is_enum_parent() {
 			match ctx.mir_ctx.ssa_hints.vec[value.get_ssa_index()] {

--- a/compiler/astoir_mir_lowering/src/introductions.rs
+++ b/compiler/astoir_mir_lowering/src/introductions.rs
@@ -21,9 +21,10 @@ pub fn handle_var_introduction_queue(block: MIRBlockReference, node: Box<HIRNode
 			let ptr = build_stack_alloc(&mut ctx.mir_ctx, new_type.get_size(&new_type, false, &ctx .hir_ctx.type_storage), new_type)?;
 		
 			ctx.mir_ctx.blocks[block].variables.insert(new_var, MIRBlockVariableSSAHint { kind: MIRBlockVariableType::Pointer, hint: Some(ptr.clone().into()) });
-			build_store(&mut ctx.mir_ctx, ptr.clone(), casted)?;
+			build_store(&mut ctx.mir_ctx, &ctx.hir_ctx.type_storage, ptr.clone(), casted)?;
 		}
 
+		return Ok(())
 	}
 
 	panic!("Invalid node")

--- a/compiler/astoir_mir_lowering/src/lib.rs
+++ b/compiler/astoir_mir_lowering/src/lib.rs
@@ -16,6 +16,7 @@ pub mod arrays;
 pub mod type_tools;
 pub mod introductions;
 pub mod casts;
+pub mod lru;
 
 pub struct MIRLoweringContext {
 	pub hir_ctx: HIRContext,

--- a/compiler/astoir_mir_lowering/src/lib.rs
+++ b/compiler/astoir_mir_lowering/src/lib.rs
@@ -1,6 +1,6 @@
 use astoir_hir::{ctx::HIRContext, nodes::{HIRNode, HIRNodeKind}};
 use astoir_mir::ctx::MIRContext;
-use compiler_typing::{raw::RawType, structs::LoweredStructTypeContainer, tree::Type};
+use compiler_typing::{SizedType, raw::RawType, structs::LoweredStructTypeContainer, tree::Type};
 use compiler_utils::utils::indexed::IndexStorage;
 use diagnostics::{DiagnosticResult, unsure_panic};
 
@@ -15,6 +15,7 @@ pub mod control;
 pub mod arrays;
 pub mod type_tools;
 pub mod introductions;
+pub mod casts;
 
 pub struct MIRLoweringContext {
 	pub hir_ctx: HIRContext,
@@ -53,7 +54,7 @@ pub fn lower_hir(ctx: HIRContext) -> DiagnosticResult<MIRContext> {
 pub fn lower_hir_generic(ctx: &MIRLoweringContext, t: &Type, generic: &RawType) -> DiagnosticResult<Type> {
 	match generic {
 		RawType::Struct(a, b) => {
-			let mut lowered_container = LoweredStructTypeContainer { fields: IndexStorage::new(), functions: IndexStorage::new() };
+			let mut lowered_container = LoweredStructTypeContainer { fields: IndexStorage::new(), functions: IndexStorage::new(), is_lowered_enum_child: false, is_lowered_enum_parent: false, lowered_enum_child: None, lowered_enum_parent: None };
 
 			for field in &b.fields.vals {
 				lowered_container.fields.vals.push(lower_hir_type(ctx, field.clone().resolve(t))?);
@@ -61,6 +62,43 @@ pub fn lower_hir_generic(ctx: &MIRLoweringContext, t: &Type, generic: &RawType) 
 
 			return Ok(Type::GenericLowered(RawType::LoweredStruct(*a, lowered_container)));
 		},
+
+		RawType::EnumEntry(container) => {
+			let mut lowered_container = LoweredStructTypeContainer { fields: IndexStorage::new(), functions: IndexStorage::new(), is_lowered_enum_child: true, is_lowered_enum_parent: false, lowered_enum_child: Some(container.clone()), lowered_enum_parent: None };
+
+			let parent = match &ctx.hir_ctx.type_storage.types.vals[container.parent] {
+				RawType::Enum(container) => container.clone(),
+				_ => panic!("Enum parent not enum")
+			};
+
+			lowered_container.fields.vals.push(Type::GenericLowered(parent.get_hint_type())); // Enum entry hint
+
+			for field in &container.fields.vals {
+				lowered_container.fields.vals.push(lower_hir_type(ctx, field.clone().resolve(t))?);
+			}
+
+			return Ok(Type::GenericLowered(RawType::LoweredStruct(false, lowered_container))); 
+		},
+
+		RawType::Enum(container) => {
+			let mut lowered_container = LoweredStructTypeContainer { fields: IndexStorage::new(), functions: IndexStorage::new(), is_lowered_enum_child: false, is_lowered_enum_parent: true, lowered_enum_parent: Some(container.clone()), lowered_enum_child: None };
+
+			let mut entry_size = 0;
+
+			let info = t.get_generic_info();
+
+			for entry in &container.entries {
+				let lowered = lower_hir_type(ctx, Type::Generic(entry.1.clone(), info.0.clone(), info.1.clone()))?;
+
+				entry_size = entry_size.max(lowered.get_generic(&ctx.hir_ctx.type_storage).get_size(&lowered, false, &ctx.hir_ctx.type_storage))
+			}
+
+			lowered_container.fields.vals.push(Type::GenericLowered(container.get_hint_type()));
+
+			lowered_container.fields.vals.push(Type::GenericLowered(RawType::Integer(entry_size, false)));
+			
+			return Ok(Type::GenericLowered(RawType::LoweredStruct(false, lowered_container))); 
+		}
 
 		_ => return Ok(Type::GenericLowered(generic.clone()))
 	};

--- a/compiler/astoir_mir_lowering/src/lru.rs
+++ b/compiler/astoir_mir_lowering/src/lru.rs
@@ -1,0 +1,35 @@
+use astoir_hir::{nodes::{HIRNode, HIRNodeKind}, structs::StructLRUStep};
+use astoir_mir::{blocks::refer::MIRBlockReference, builder::build_field_pointer, vals::{base::BaseMIRValue, refer::MIRVariableReference}};
+use diagnostics::DiagnosticResult;
+
+use crate::MIRLoweringContext;
+
+pub fn lower_hir_lru_step(block: MIRBlockReference, step: StructLRUStep, ctx: &mut MIRLoweringContext, curr: Option<BaseMIRValue>) -> DiagnosticResult<BaseMIRValue> {
+	if let StructLRUStep::VariableStep { variable } = step {
+		if curr.is_none() {
+			return Ok(ctx.mir_ctx.blocks[block].get_variable_ref(variable)?.as_pointer_ref()?.into());
+		}
+
+		let ptr = curr.unwrap().as_ptr()?;
+
+		return Ok(build_field_pointer(&mut ctx.mir_ctx, ptr, variable)?.into())
+	}
+
+	panic!("Invalid step!")
+}
+
+pub fn lower_hir_lru(block: MIRBlockReference, node: Box<HIRNode>, ctx: &mut MIRLoweringContext) -> DiagnosticResult<BaseMIRValue> {
+	if let HIRNodeKind::StructLRU { steps, last: _ } = node.kind {
+		let mut curr = lower_hir_lru_step(block, steps[0].clone(), ctx, None)?;
+
+		for i in 1..steps.len() {
+			curr = lower_hir_lru_step(block, steps[i].clone(), ctx, Some(curr))?
+		}
+
+		let val = MIRVariableReference::from(curr.as_ptr()?);
+
+		return Ok(val.read(block, &mut ctx.mir_ctx)?);
+	}
+
+	panic!("Invalid node!")
+}

--- a/compiler/astoir_mir_lowering/src/math.rs
+++ b/compiler/astoir_mir_lowering/src/math.rs
@@ -34,7 +34,7 @@ pub fn lower_hir_math_operation(block: MIRBlockReference, node: Box<HIRNode>, ct
 		if assignment {
 			let v = ptr.unwrap();
 
-			v.write(block, &mut ctx.mir_ctx, val.clone())?;
+			v.write(block, &mut ctx.mir_ctx, val.clone(), &ctx.hir_ctx.type_storage)?;
 		}
 
 		return Ok(val)

--- a/compiler/astoir_mir_lowering/src/type_tools.rs
+++ b/compiler/astoir_mir_lowering/src/type_tools.rs
@@ -5,7 +5,7 @@ use astoir_mir::{blocks::refer::MIRBlockReference, builder::{build_comp_eq, buil
 use compiler_typing::{SizedType, raw::RawType, tree::Type};
 use diagnostics::{DiagnosticResult, DiagnosticSpanOrigin, builders::{make_req_type_kind, make_type_not_partof}};
 
-use crate::{MIRLoweringContext, lower_hir_type, values::lower_hir_value};
+use crate::{MIRLoweringContext, lower_hir_type, values::lower_hir_value, vars::lower_hir_variable_reference};
 
 pub fn is_enum_value_of_kind<K: DiagnosticSpanOrigin>(block: MIRBlockReference, val: BaseMIRValue, enum_entry: RawType, ctx: &mut MIRLoweringContext, origin: &K) -> DiagnosticResult<MIRIntValue> {
 	let enum_type = match ctx.mir_ctx.ssa_hints.get_hint(val.get_ssa_index()).get_type().as_generic_lowered_safe(origin)? {
@@ -51,11 +51,26 @@ pub fn is_enum_value_of_kind<K: DiagnosticSpanOrigin>(block: MIRBlockReference, 
 pub fn cast_to_enum_child<K: DiagnosticSpanOrigin>(block: MIRBlockReference, val: BaseMIRValue, enum_entry: RawType, ctx: &mut MIRLoweringContext, origin: &K) -> DiagnosticResult<BaseMIRValue> {
 	let enum_type = match ctx.mir_ctx.ssa_hints.get_hint(val.get_ssa_index()).get_type().as_generic_lowered_safe(origin)? {
 		RawType::Enum(v) => v,
+		RawType::LoweredStruct(_, container) => {
+			if !container.is_lowered_enum_parent {
+				return Err(make_req_type_kind(origin, &"enum parent".to_string()).into())
+			}
+
+			container.lowered_enum_parent.unwrap()
+		},
+		
 		_ => return Err(make_req_type_kind(origin, &"enum parent".to_string()).into())
 	};
 
 	let enum_entry_container = match &enum_entry {
 		RawType::EnumEntry(v) => v,
+		RawType::LoweredStruct(_, container) => {
+			if !container.is_lowered_enum_child {
+				return Err(make_req_type_kind(origin, &"enum parent".to_string()).into())
+			}
+
+			container.lowered_enum_child.as_ref().unwrap()
+		},
 		_ => return Err(make_req_type_kind(origin, &"enum child".to_string()).into())
 	};
 
@@ -68,7 +83,7 @@ pub fn cast_to_enum_child<K: DiagnosticSpanOrigin>(block: MIRBlockReference, val
 
 pub fn lower_hir_unwrap_cond(block: MIRBlockReference, node: Box<HIRNode>, ctx: &mut MIRLoweringContext) -> DiagnosticResult<BaseMIRValue> {
 	if let HIRNodeKind::UnwrapCondition { original, new_type, new_var, unsafe_unwrap } = node.kind.clone() {
-		let original = lower_hir_value(block, original, ctx)?;
+		let original = lower_hir_variable_reference(block, &original, ctx)?.as_pointer_ref()?.into();
 		let new_type = lower_hir_type(ctx, new_type)?;
 
 		let cond;

--- a/compiler/astoir_mir_lowering/src/type_tools.rs
+++ b/compiler/astoir_mir_lowering/src/type_tools.rs
@@ -10,11 +10,27 @@ use crate::{MIRLoweringContext, lower_hir_type, values::lower_hir_value};
 pub fn is_enum_value_of_kind<K: DiagnosticSpanOrigin>(block: MIRBlockReference, val: BaseMIRValue, enum_entry: RawType, ctx: &mut MIRLoweringContext, origin: &K) -> DiagnosticResult<MIRIntValue> {
 	let enum_type = match ctx.mir_ctx.ssa_hints.get_hint(val.get_ssa_index()).get_type().as_generic_lowered_safe(origin)? {
 		RawType::Enum(v) => v,
-		_ => return Err(make_req_type_kind(origin, &"enum parent".to_string()).into())
+		RawType::LoweredStruct(_, container) => {
+			if !container.is_lowered_enum_parent {
+				return Err(make_req_type_kind(origin, &"enum parent".to_string()).into())
+			}
+
+			container.lowered_enum_parent.unwrap()
+		}
+		_ => {
+			return Err(make_req_type_kind(origin, &"enum parent".to_string()).into())
+		}
 	};
 
 	let enum_entry = match enum_entry {
 		RawType::EnumEntry(v) => v,
+		RawType::LoweredStruct(_, container) => {
+			if !container.is_lowered_enum_child {
+				return Err(make_req_type_kind(origin, &"enum child".to_string()).into())
+			}
+
+			container.lowered_enum_child.unwrap()
+		}
 		_ => return Err(make_req_type_kind(origin, &"enum child".to_string()).into())
 	};
 

--- a/compiler/astoir_mir_lowering/src/values/mod.rs
+++ b/compiler/astoir_mir_lowering/src/values/mod.rs
@@ -20,7 +20,7 @@ pub fn lower_hir_value(block: MIRBlockReference, node: Box<HIRNode>, ctx: &mut M
 		HIRNodeKind::BooleanOperator { .. } => return Ok(lower_hir_boolean_operator(block, node, ctx)?.into()),
 		HIRNodeKind::MathOperation { .. } => return Ok(lower_hir_math_operation(block, node, ctx)?),
 		HIRNodeKind::ArrayIndexAccess { .. } => return Ok(lower_hir_aray_index_access(block, node, ctx)?),
-		HIRNodeKind::StructVariableInitializerValue { .. } => return Ok(lower_hir_struct_init(block, node, ctx)?.into()),
+		HIRNodeKind::StructInitializer { .. } => return Ok(lower_hir_struct_init(block, node, ctx)?.into()),
 		HIRNodeKind::UnwrapValue { .. } => lower_hir_unwrap_value(block, node, ctx),
 		HIRNodeKind::UnwrapCondition { .. } => lower_hir_unwrap_cond(block, node, ctx),
 		HIRNodeKind::ArrayVariableInitializerValue { .. } | HIRNodeKind::ArrayVariableInitializerValueSameValue { .. } => lower_array_init(block, node, ctx),

--- a/compiler/astoir_mir_lowering/src/values/mod.rs
+++ b/compiler/astoir_mir_lowering/src/values/mod.rs
@@ -20,7 +20,7 @@ pub fn lower_hir_value(block: MIRBlockReference, node: Box<HIRNode>, ctx: &mut M
 		HIRNodeKind::BooleanOperator { .. } => return Ok(lower_hir_boolean_operator(block, node, ctx)?.into()),
 		HIRNodeKind::MathOperation { .. } => return Ok(lower_hir_math_operation(block, node, ctx)?),
 		HIRNodeKind::ArrayIndexAccess { .. } => return Ok(lower_hir_aray_index_access(block, node, ctx)?),
-		HIRNodeKind::StructInitializer { .. } => return Ok(lower_hir_struct_init(block, node, ctx)?.into()),
+		HIRNodeKind::StructInitializerTyped { .. } => return Ok(lower_hir_struct_init(block, node, ctx)?.into()),
 		HIRNodeKind::UnwrapValue { .. } => lower_hir_unwrap_value(block, node, ctx),
 		HIRNodeKind::UnwrapCondition { .. } => lower_hir_unwrap_cond(block, node, ctx),
 		HIRNodeKind::ArrayVariableInitializerValue { .. } | HIRNodeKind::ArrayVariableInitializerValueSameValue { .. } => lower_array_init(block, node, ctx),

--- a/compiler/astoir_mir_lowering/src/values/mod.rs
+++ b/compiler/astoir_mir_lowering/src/values/mod.rs
@@ -2,7 +2,7 @@ use astoir_hir::nodes::{HIRNode, HIRNodeKind};
 use astoir_mir::{blocks::refer::MIRBlockReference, builder::{build_static_array_const, build_static_array_one_const}, vals::base::BaseMIRValue};
 use diagnostics::{DiagnosticResult, DiagnosticSpanOrigin, move_current_diagnostic_pos, unsure_panic};
 
-use crate::{MIRLoweringContext, arrays::lower_hir_aray_index_access, casts::lower_cast, funcs::lower_hir_function_call, math::lower_hir_math_operation, type_tools::{lower_hir_unwrap_cond, lower_hir_unwrap_value}, values::{booleans::{lower_hir_boolean_operator, lowering_hir_boolean_condition}, consts::lower_hir_literal, structs::lower_hir_struct_init}, vars::{lower_hir_variable_reference, lower_hir_variable_reference_value}};
+use crate::{MIRLoweringContext, arrays::lower_hir_aray_index_access, casts::lower_cast, funcs::lower_hir_function_call, lru::lower_hir_lru, math::lower_hir_math_operation, type_tools::{lower_hir_unwrap_cond, lower_hir_unwrap_value}, values::{booleans::{lower_hir_boolean_operator, lowering_hir_boolean_condition}, consts::lower_hir_literal, structs::lower_hir_struct_init}, vars::{lower_hir_variable_reference, lower_hir_variable_reference_value}};
 
 pub mod consts;
 pub mod booleans;
@@ -24,6 +24,7 @@ pub fn lower_hir_value(block: MIRBlockReference, node: Box<HIRNode>, ctx: &mut M
 		HIRNodeKind::UnwrapValue { .. } => lower_hir_unwrap_value(block, node, ctx),
 		HIRNodeKind::UnwrapCondition { .. } => lower_hir_unwrap_cond(block, node, ctx),
 		HIRNodeKind::CastValue { .. } => lower_cast(block, node, ctx),
+		HIRNodeKind::StructLRU { .. } => lower_hir_lru(block, node, ctx),
 		HIRNodeKind::ArrayVariableInitializerValue { .. } | HIRNodeKind::ArrayVariableInitializerValueSameValue { .. } => lower_array_init(block, node, ctx),
 		HIRNodeKind::FunctionCall { .. } => {
 			let res = lower_hir_function_call(block, node, ctx)?;

--- a/compiler/astoir_mir_lowering/src/values/mod.rs
+++ b/compiler/astoir_mir_lowering/src/values/mod.rs
@@ -2,7 +2,7 @@ use astoir_hir::nodes::{HIRNode, HIRNodeKind};
 use astoir_mir::{blocks::refer::MIRBlockReference, builder::{build_static_array_const, build_static_array_one_const}, vals::base::BaseMIRValue};
 use diagnostics::{DiagnosticResult, DiagnosticSpanOrigin, move_current_diagnostic_pos, unsure_panic};
 
-use crate::{MIRLoweringContext, arrays::lower_hir_aray_index_access, funcs::lower_hir_function_call, math::lower_hir_math_operation, type_tools::{lower_hir_unwrap_cond, lower_hir_unwrap_value}, values::{booleans::{lower_hir_boolean_operator, lowering_hir_boolean_condition}, consts::lower_hir_literal, structs::lower_hir_struct_init}, vars::{lower_hir_variable_reference, lower_hir_variable_reference_value}};
+use crate::{MIRLoweringContext, arrays::lower_hir_aray_index_access, casts::lower_cast, funcs::lower_hir_function_call, math::lower_hir_math_operation, type_tools::{lower_hir_unwrap_cond, lower_hir_unwrap_value}, values::{booleans::{lower_hir_boolean_operator, lowering_hir_boolean_condition}, consts::lower_hir_literal, structs::lower_hir_struct_init}, vars::{lower_hir_variable_reference, lower_hir_variable_reference_value}};
 
 pub mod consts;
 pub mod booleans;
@@ -23,6 +23,7 @@ pub fn lower_hir_value(block: MIRBlockReference, node: Box<HIRNode>, ctx: &mut M
 		HIRNodeKind::StructInitializerTyped { .. } => return Ok(lower_hir_struct_init(block, node, ctx)?.into()),
 		HIRNodeKind::UnwrapValue { .. } => lower_hir_unwrap_value(block, node, ctx),
 		HIRNodeKind::UnwrapCondition { .. } => lower_hir_unwrap_cond(block, node, ctx),
+		HIRNodeKind::CastValue { .. } => lower_cast(block, node, ctx),
 		HIRNodeKind::ArrayVariableInitializerValue { .. } | HIRNodeKind::ArrayVariableInitializerValueSameValue { .. } => lower_array_init(block, node, ctx),
 		HIRNodeKind::FunctionCall { .. } => {
 			let res = lower_hir_function_call(block, node, ctx)?;
@@ -34,7 +35,7 @@ pub fn lower_hir_value(block: MIRBlockReference, node: Box<HIRNode>, ctx: &mut M
 			return Ok(res.unwrap());
 		}
 
-		_ => panic!("Invalid node")
+		_ => panic!("Invalid node {:#?}", node)
 	}
 }
 

--- a/compiler/astoir_mir_lowering/src/values/structs.rs
+++ b/compiler/astoir_mir_lowering/src/values/structs.rs
@@ -5,7 +5,7 @@ use diagnostics::DiagnosticResult;
 use crate::{MIRLoweringContext, lower_hir_type, values::lower_hir_value};
 
 pub fn lower_hir_struct_init(block: MIRBlockReference, node: Box<HIRNode>, ctx: &mut MIRLoweringContext) -> DiagnosticResult<MIRStructValue> {
-	if let HIRNodeKind::StructVariableInitializerValue { t, fields } = node.kind {
+	if let HIRNodeKind::StructInitializerTyped { t, fields } = node.kind {
 		let mut values = vec![];
 	
 		for field in fields {

--- a/compiler/astoir_mir_lowering/src/values/structs.rs
+++ b/compiler/astoir_mir_lowering/src/values/structs.rs
@@ -1,5 +1,6 @@
 use astoir_hir::nodes::{HIRNode, HIRNodeKind};
-use astoir_mir::{blocks::refer::MIRBlockReference, builder::build_static_struct_const, vals::structs::MIRStructValue};
+use astoir_mir::{blocks::refer::MIRBlockReference, builder::{build_static_struct_const, build_unsigned_int_const}, vals::structs::MIRStructValue};
+use compiler_typing::{SizedType, raw::RawType, tree::Type};
 use diagnostics::DiagnosticResult;
 
 use crate::{MIRLoweringContext, lower_hir_type, values::lower_hir_value};
@@ -7,13 +8,35 @@ use crate::{MIRLoweringContext, lower_hir_type, values::lower_hir_value};
 pub fn lower_hir_struct_init(block: MIRBlockReference, node: Box<HIRNode>, ctx: &mut MIRLoweringContext) -> DiagnosticResult<MIRStructValue> {
 	if let HIRNodeKind::StructInitializerTyped { t, fields } = node.kind {
 		let mut values = vec![];
-	
-		for field in fields {
-			values.push(lower_hir_value(block, field, ctx)?);
+
+		match t.get_generic(&ctx.hir_ctx.type_storage) {
+			RawType::Struct(_, _) => {
+				for field in fields {
+					values.push(lower_hir_value(block, field, ctx)?);
+				}
+			},
+
+			RawType::EnumEntry(container) => {
+
+				let parent = match &ctx.hir_ctx.type_storage.types.vals[container.parent] {
+					RawType::Enum(container) => container.clone(),
+					_ => panic!("Enum parent not enum")
+				};
+
+				let hint = build_unsigned_int_const(&mut ctx.mir_ctx, container.child as u128, parent.get_hint_type().get_size(&Type::GenericLowered(parent.get_hint_type()), false, &ctx.hir_ctx.type_storage))?;
+
+				values.push(hint.into());
+
+				for field in fields {
+					values.push(lower_hir_value(block, field, ctx)?);
+				}
+			}
+
+			_ => panic!("Invalid type for a StructInitializedTyped")
 		}
 
 		let lowered_type = lower_hir_type(ctx, t)?.get_generic(&ctx.hir_ctx.type_storage);
-
+		
 		return build_static_struct_const(&mut ctx.mir_ctx, lowered_type, values);
 	}
 

--- a/compiler/astoir_mir_lowering/src/vars.rs
+++ b/compiler/astoir_mir_lowering/src/vars.rs
@@ -30,7 +30,7 @@ pub fn lower_hir_variable_declaration(block_id: MIRBlockReference, node: Box<HIR
 			if default_val.is_some() {
 				let val = lower_hir_value(block_id, default_val.unwrap(), ctx)?;
 			
-				build_store(&mut ctx.mir_ctx, ptr.clone(), val)?;
+				build_store(&mut ctx.mir_ctx, &ctx.hir_ctx.type_storage, ptr.clone(), val)?;
 			}
 		}
 
@@ -64,7 +64,7 @@ pub fn lower_hir_variable_assignment(block: MIRBlockReference, node: Box<HIRNode
  
 		let val = lower_hir_value(block, val, ctx)?;
 
-		variable_ref.write(block, &mut ctx.mir_ctx, val)?;
+		variable_ref.write(block, &mut ctx.mir_ctx, val, &ctx.hir_ctx.type_storage)?;
 		return Ok(true);
 	}
 

--- a/compiler/compiler_typing/src/enums.rs
+++ b/compiler/compiler_typing/src/enums.rs
@@ -16,7 +16,7 @@ pub struct RawEnumTypeContainer {
 	pub self_ref: usize,
 	pub type_params: TypeParameterContainer,
 	pub functions: IndexStorage<TypedFunction>,
-	entries: HashMap<HashedString, RawType>
+	pub entries: HashMap<HashedString, RawType>
 }
 
 impl RawEnumTypeContainer {

--- a/compiler/compiler_typing/src/raw.rs
+++ b/compiler/compiler_typing/src/raw.rs
@@ -46,6 +46,15 @@ impl RawType {
 		}
 	}
 	
+	pub fn is_field_based(&self) -> bool {
+		match self {
+			RawType::Struct(_, _) => true,
+			RawType::EnumEntry(_) => true,
+
+			_ => false
+		}
+	}
+
 	pub fn is_signed(&self) -> bool {
 		match self {
 			Self::Integer(_, signed) => *signed,

--- a/compiler/compiler_typing/src/raw.rs
+++ b/compiler/compiler_typing/src/raw.rs
@@ -45,7 +45,23 @@ impl RawType {
 			_ => 0
 		}
 	}
+
+	pub fn is_enum_parent(&self) -> bool {
+		match self {
+			Self::Enum(_) => true,
+			Self::LoweredStruct(_, b) => b.is_lowered_enum_parent,
+			_ => false
+		}
+	}
 	
+	pub fn is_enum_child(&self) -> bool {
+		match self {
+			Self::EnumEntry(_) => true,
+			Self::LoweredStruct(_, b) => b.is_lowered_enum_child,
+			_ => false
+		}
+	}
+
 	pub fn is_field_based(&self) -> bool {
 		match self {
 			RawType::Struct(_, _) => true,
@@ -152,6 +168,10 @@ impl RawType {
 			(Self::SizedInteger(_), Self::Floating(_, _)) => true,
 
 			(Self::StaticString, Self::Pointer) => true,
+
+			(Self::EnumEntry(container), Self::Enum(c2)) => {
+				return container.parent == c2.self_ref;
+			}
 
 			_ => false
 		}

--- a/compiler/compiler_typing/src/structs.rs
+++ b/compiler/compiler_typing/src/structs.rs
@@ -1,7 +1,7 @@
 use compiler_utils::utils::indexed::IndexStorage;
 use diagnostics::{DiagnosticResult, builders::{make_cannot_find_type_field, make_cannot_find_type_function}};
 
-use crate::{SizedType, StructuredType, TypeParameterContainer, TypeReference, TypedFunction, storage::TypeStorage, tree::Type};
+use crate::{SizedType, StructuredType, TypeParameterContainer, TypeReference, TypedFunction, enums::{RawEnumEntryContainer, RawEnumTypeContainer}, storage::TypeStorage, tree::Type};
 
 /// Container for structure types
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -14,6 +14,10 @@ pub struct RawStructTypeContainer {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LoweredStructTypeContainer {
 	pub fields: IndexStorage<Type>,
+	pub is_lowered_enum_child: bool,
+	pub is_lowered_enum_parent: bool,
+	pub lowered_enum_parent: Option<RawEnumTypeContainer>, 
+	pub lowered_enum_child: Option<RawEnumEntryContainer>,
 	pub functions: IndexStorage<usize>
 }
 

--- a/compiler/compiler_typing/src/tree.rs
+++ b/compiler/compiler_typing/src/tree.rs
@@ -114,9 +114,17 @@ impl Type {
 	pub fn as_generic_lowered_safe<K: DiagnosticSpanOrigin>(&self, origin: &K) -> DiagnosticResult<RawType> {
 		match self {
 			Type::GenericLowered(a) => return Ok(a.clone()),
-			_ => return Err(make_req_type_kind(origin, &"a generic".to_string()).into())
+			_ => return Err(make_req_type_kind(origin, &"generic".to_string()).into())
 		}
 	}
+
+	pub fn as_generic_safe<K: DiagnosticSpanOrigin>(&self, origin: &K) -> DiagnosticResult<RawType> {
+		match self {
+			Type::Generic(a, _, _) => return Ok(a.clone()),
+			_ => return Err(make_req_type_kind(origin, &"generic".to_string()).into())
+		}
+	}
+
 
 	pub fn as_generic_lowered(&self) -> RawType {
 		match self {
@@ -229,7 +237,9 @@ impl Display for Type {
 				format!("{}[{}]", inner, size)
 			},
 
-			Self::Generic(_, _, _) => unsure_panic!("cannot display unlowered generic"),
+			Self::Generic(low, _, _) => {
+				format!("{}", low)
+			}
 
 			Self::GenericLowered(low ) => {
 				format!("{}", low)

--- a/compiler/compiler_typing/src/tree.rs
+++ b/compiler/compiler_typing/src/tree.rs
@@ -168,6 +168,8 @@ impl Type {
 			return (types.clone(), sizes.clone())
 		}
 
+		println!("{:#?}", self);
+
 		return self.get_inner_type().get_generic_info();
 	}
 

--- a/compiler/diagnostics/src/diagnostic.rs
+++ b/compiler/diagnostics/src/diagnostic.rs
@@ -1,6 +1,6 @@
 //! The core of diagnostics
 
-use std::{fmt::Display, fs, io::Error};
+use std::{backtrace::Backtrace, fmt::Display, fs, io::Error};
 
 use colored::{ColoredString, Colorize};
 use compiler_utils::Position;
@@ -57,7 +57,6 @@ impl Display for Level {
 	}
 }
 
-#[derive(Clone)]
 pub struct Diagnostic {
 	pub level: Level,
 	pub code: usize,
@@ -67,12 +66,35 @@ pub struct Diagnostic {
 	pub spans: Vec<Span>,
 
 	pub note: Vec<String>,
-	pub help: Vec<String>
+	pub help: Vec<String>,
+
+	pub backtrace: Option<Backtrace>
+}
+
+impl Clone for Diagnostic {
+	fn clone(&self) -> Self {
+		Diagnostic { level: self.level.clone(), code: self.code, message: self.message.clone(), primary_span: self.primary_span.clone(), spans: self.spans.clone(), note: self.note.clone(), help: self.help.clone(), backtrace: Diagnostic::capture_backtrace() }
+	}
 }
 
 impl Diagnostic {
+	pub fn capture_backtrace() -> Option<Backtrace> {
+		if cfg!(debug_assertions) {
+            Some(Backtrace::capture())
+        } else {
+            None
+        }
+	}
+
+	pub fn maybe_display_backtrace(&self, fmt: &mut std::fmt::Formatter<'_>) {
+		if cfg!(debug_assertions) {
+			writeln!(fmt, "Internally captured in:");
+			writeln!(fmt, "{}", self.backtrace.as_ref().unwrap());
+		}
+	}
+
 	pub fn new(level: Level, decl: (usize, &str), primary_span: Span, spans: Vec<Span>, note: Vec<String>, help: Vec<String>) -> Self {
-		let d = Diagnostic { level, code: decl.0, message: decl.1.to_string(), primary_span, spans, note, help};
+		let d = Diagnostic { level, code: decl.0, message: decl.1.to_string(), primary_span, spans, note, help, backtrace: Diagnostic::capture_backtrace() };
 		
 		d.push_to_storage();
 
@@ -80,7 +102,7 @@ impl Diagnostic {
  	}
 
 	pub fn new_base(level: Level, code: usize, message: String, primary_span: Span, spans: Vec<Span>, note: Vec<String>, help: Vec<String>) -> Self {
-		let d = Diagnostic { level, code, message, primary_span, spans, note, help};
+		let d = Diagnostic { level, code, message, primary_span, spans, note, help, backtrace: Diagnostic::capture_backtrace() };
 
 		d.push_to_storage();
 
@@ -224,6 +246,8 @@ impl Display for Diagnostic {
 
 			ind += 1;
 		}
+
+		self.maybe_display_backtrace(f);
 		
 		Ok(())
 	}

--- a/compiler/llvm_ir_bridge/src/insts.rs
+++ b/compiler/llvm_ir_bridge/src/insts.rs
@@ -578,6 +578,21 @@ pub fn bridge_llvm_instruction(instruction: MIRBlockHeldInstruction, func: usize
 			let func = bridge.functions[func].clone().inner;
 
 			func.get_nth_param(ind as u32)
+		},
+
+		MIRInstruction::MemoryCopy { src, dest, sz } => {
+			let src: BaseMIRValue = src.into();
+			let dest: BaseMIRValue = dest.into();
+
+			let llvm_src = bridge.values[&src.get_ssa_index()].clone();
+			let llvm_dest = bridge.values[&dest.get_ssa_index()].clone();
+
+			let sz_type = bridge.types.convert_raw(RawType::Integer(32, false)).into_int_type();
+			let sz = sz_type.const_int(sz as u64, false);
+
+			llvm_to_base_returnless!(bridge.builder.build_memcpy(llvm_dest.inner.into_pointer_value(), 1, llvm_src.into_pointer_value(), 1, sz));
+
+			None
 		}
 
 		_ => None


### PR DESCRIPTION
Changelog:
- Changed the structured type declaration syntax from `new <type> { fields.. }` to `{ fields...}`
- Added enum value creation using the structured type declaration syntax
- Made the struct initialize type less at first, allowing to remove the <type> mention at creation
- Changed array initialization syntax from `{0.5}` to `[0.5]`
- Renamed from `StructVariableInitializerValue` to `StructInitializer` for clarity
- Reworked array value initializer parsing
- Added unsafe memory copy instruction (`unsmemcopy`)
- Added a fall back to `build_store` when the value type is a child enum and the pointer is a parent enum to use `unsmemcopy` instead of failing
- Added HIR type resolving system