### PR TITLE
[feat] Better Syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ out
 out.*
 
 *.qf
-*.qfmir
 *.llvm
+*.air
 
 !examples/**.qf

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,7 @@ dependencies = [
  "ast",
  "ast_parser",
  "astoir",
+ "astoir_mir",
  "clap",
  "compiler_utils",
  "diagnostics",

--- a/compiler/ast/src/lib.rs
+++ b/compiler/ast/src/lib.rs
@@ -4,5 +4,6 @@
 
 pub mod ctx;
 pub mod operators;
+pub mod ranges;
 pub mod tree;
 pub mod types;

--- a/compiler/ast/src/operators.rs
+++ b/compiler/ast/src/operators.rs
@@ -72,15 +72,23 @@ pub fn parse_compare_operator(
         _ => false,
     };
 
+    if eq {
+        *ind += 1;
+    }
+
     let op = match tokens[*ind].tok_type {
         LexerTokenType::EqualSign => {
-            tokens[*ind + 1].expects(LexerTokenType::EqualSign)?;
+            if !eq {
+                tokens[*ind + 1].expects(LexerTokenType::EqualSign)?;
+            }
 
             ComparingOperator::Equal
         }
 
         LexerTokenType::ExclamationMark => {
-            tokens[*ind + 1].expects(LexerTokenType::EqualSign)?;
+            if !eq {
+                tokens[*ind + 1].expects(LexerTokenType::EqualSign)?;
+            }
 
             ComparingOperator::NotEqual
         }
@@ -105,6 +113,8 @@ pub fn parse_compare_operator(
             return Err(make_unexpected_simple_error(&tokens[*ind], &tokens[*ind].tok_type).into());
         }
     };
+
+    *ind += 1;
 
     return Ok(op);
 }

--- a/compiler/ast/src/ranges.rs
+++ b/compiler/ast/src/ranges.rs
@@ -1,0 +1,6 @@
+use crate::tree::ASTTreeNode;
+
+pub struct ASTRange {
+    pub min: Box<ASTTreeNode>,
+    pub max: Box<ASTTreeNode>,
+}

--- a/compiler/ast/src/ranges.rs
+++ b/compiler/ast/src/ranges.rs
@@ -1,5 +1,6 @@
 use crate::tree::ASTTreeNode;
 
+#[derive(Debug, PartialEq, Clone)]
 pub struct ASTRange {
     pub min: Box<ASTTreeNode>,
     pub max: Box<ASTTreeNode>,

--- a/compiler/ast/src/tree.rs
+++ b/compiler/ast/src/tree.rs
@@ -175,7 +175,7 @@ pub enum ASTTreeNodeKind {
     },
 
     RangedForBlock {
-        var: HashedString,
+        var: Box<ASTTreeNode>,
         range: ASTRange,
         body: Vec<Box<ASTTreeNode>>,
     },

--- a/compiler/ast/src/tree.rs
+++ b/compiler/ast/src/tree.rs
@@ -15,7 +15,7 @@ use diagnostics::{
     diagnostic::{Diagnostic, Span, SpanKind, SpanPosition},
 };
 
-use crate::types::ASTType;
+use crate::{ranges::ASTRange, types::ASTType};
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct FunctionDeclarationArgument {
@@ -166,10 +166,17 @@ pub enum ASTTreeNodeKind {
         cond: Box<ASTTreeNode>,
         body: Vec<Box<ASTTreeNode>>,
     },
+
     ForBlock {
         initial_state: Box<ASTTreeNode>,
         cond: Box<ASTTreeNode>,
         increment: Box<ASTTreeNode>,
+        body: Vec<Box<ASTTreeNode>>,
+    },
+
+    RangedForBlock {
+        var: HashedString,
+        range: ASTRange,
         body: Vec<Box<ASTTreeNode>>,
     },
 
@@ -364,7 +371,7 @@ impl Display for ASTTreeNodeKind {
             Self::ReturnStatement { .. } => "return statement",
             Self::StaticVariableDeclaration { .. } => "static variable declaration",
             Self::WhileBlock { .. } => "while block",
-            Self::ForBlock { .. } => "for block",
+            Self::ForBlock { .. } | Self::RangedForBlock { .. } => "for block",
             Self::FunctionCall { .. } => "function call",
             Self::FunctionDeclaration { .. } => "function declaration",
             Self::ExternFunctionDeclaration { .. } => "extern function declaration",

--- a/compiler/ast/src/tree.rs
+++ b/compiler/ast/src/tree.rs
@@ -80,9 +80,9 @@ pub enum ASTTreeNodeKind {
 
     Dereference(Box<ASTTreeNode>),
 
-    /// A stub to mark a value as being a modifying deref
     DereferenceModify {
         pointer: Box<ASTTreeNode>,
+        val: Box<ASTTreeNode>,
     },
 
     ReferenceGrab(Box<ASTTreeNode>),

--- a/compiler/ast/src/tree.rs
+++ b/compiler/ast/src/tree.rs
@@ -78,7 +78,13 @@ pub enum ASTTreeNodeKind {
 
     VariableReference(HashedString),
 
-    PointerGrab(Box<ASTTreeNode>),
+    Dereference(Box<ASTTreeNode>),
+
+    DereferenceModify {
+        pointer: Box<ASTTreeNode>,
+        new_value: Box<ASTTreeNode>,
+    },
+
     ReferenceGrab(Box<ASTTreeNode>),
 
     StructInitializer {
@@ -356,7 +362,8 @@ impl Display for ASTTreeNodeKind {
             Self::BooleanBasedConditionMember { .. } => "boolean condition",
             Self::MathResult { .. } => "math operation",
             Self::VariableReference(_) => "variable reference",
-            Self::PointerGrab(_) => "pointer grabbing",
+            Self::DereferenceModify { .. } => "modifying dereference",
+            Self::Dereference(_) => "dereference",
             Self::ReferenceGrab(_) => "reference",
             Self::StructInitializer { .. } => "struct value initializer",
             Self::ArrayVariableInitializerValue { .. }

--- a/compiler/ast/src/tree.rs
+++ b/compiler/ast/src/tree.rs
@@ -185,7 +185,7 @@ pub enum ASTTreeNodeKind {
         requires_this: bool,
     },
 
-    ShadowFunctionDeclaration {
+    ExternFunctionDeclaration {
         func_name: HashedString,
         args: Vec<FunctionDeclarationArgument>,
         return_type: Option<ASTType>,
@@ -222,7 +222,7 @@ impl ASTTreeNodeKind {
             ASTTreeNodeKind::FunctionDeclaration { .. }
                 | ASTTreeNodeKind::EnumDeclaration { .. }
                 | ASTTreeNodeKind::StaticVariableDeclaration { .. }
-                | ASTTreeNodeKind::ShadowFunctionDeclaration { .. }
+                | ASTTreeNodeKind::ExternFunctionDeclaration { .. }
                 | ASTTreeNodeKind::StructLayoutDeclaration { .. }
         );
     }
@@ -239,7 +239,7 @@ impl ASTTreeNodeKind {
                 return Some(HashedString::new(func_name.val.to_string()));
             }
 
-            ASTTreeNodeKind::ShadowFunctionDeclaration {
+            ASTTreeNodeKind::ExternFunctionDeclaration {
                 func_name,
                 args: _,
                 return_type: _,
@@ -367,7 +367,7 @@ impl Display for ASTTreeNodeKind {
             Self::ForBlock { .. } => "for block",
             Self::FunctionCall { .. } => "function call",
             Self::FunctionDeclaration { .. } => "function declaration",
-            Self::ShadowFunctionDeclaration { .. } => "shadow function declaration",
+            Self::ExternFunctionDeclaration { .. } => "extern function declaration",
             Self::StructLRFunction { .. } => "struct LRU function usage",
             Self::StructLRVariable { .. } => "struct LRU variable usage",
             Self::StructLayoutDeclaration { .. } => "struct / layout declaration",

--- a/compiler/ast/src/tree.rs
+++ b/compiler/ast/src/tree.rs
@@ -80,9 +80,9 @@ pub enum ASTTreeNodeKind {
 
     Dereference(Box<ASTTreeNode>),
 
+    /// A stub to mark a value as being a modifying deref
     DereferenceModify {
         pointer: Box<ASTTreeNode>,
-        new_value: Box<ASTTreeNode>,
     },
 
     ReferenceGrab(Box<ASTTreeNode>),

--- a/compiler/ast_parser/src/control/for_loop.rs
+++ b/compiler/ast_parser/src/control/for_loop.rs
@@ -4,8 +4,8 @@ use lexer::token::{LexerToken, LexerTokenType};
 use ast::tree::{ASTTreeNode, ASTTreeNodeKind};
 
 use crate::{
-    functions::parse_node_body, parser::parse_ast_node_in_body, value::parse_ast_value,
-    variables::decl::parse_variable_declaration,
+    functions::parse_node_body, parser::parse_ast_node_in_body, ranges::parse_value_range,
+    value::parse_ast_value, variables::decl::parse_variable_declaration,
 };
 
 pub fn parse_for_loop(
@@ -14,9 +14,16 @@ pub fn parse_for_loop(
 ) -> DiagnosticResult<Box<ASTTreeNode>> {
     let start = tokens[*ind].pos.clone();
 
+    if tokens[*ind + 1].tok_type != LexerTokenType::ParenOpen {
+        return parse_for_ranged_loop(tokens, ind);
+    }
+
     *ind += 1;
 
     tokens[*ind].expects(LexerTokenType::ParenOpen)?;
+    *ind += 1;
+
+    tokens[*ind].expects(LexerTokenType::Var)?;
 
     let initial = parse_variable_declaration(tokens, ind)?;
 
@@ -49,4 +56,34 @@ pub fn parse_for_loop(
         start,
         end,
     )));
+}
+
+pub fn parse_for_ranged_loop(
+    tokens: &Vec<LexerToken>,
+    ind: &mut usize,
+) -> DiagnosticResult<Box<ASTTreeNode>> {
+    let start = tokens[*ind].pos.clone();
+
+    let var = parse_variable_declaration(tokens, ind)?;
+
+    tokens[*ind].expects(LexerTokenType::EqualSign)?;
+    *ind += 1;
+
+    tokens[*ind].expects(LexerTokenType::AngelBracketClose)?;
+    *ind += 1;
+
+    let range = parse_value_range(tokens, ind)?;
+
+    tokens[*ind].expects(LexerTokenType::BracketOpen)?;
+    *ind += 1;
+
+    let body = parse_node_body(tokens, ind)?;
+
+    let end = tokens[*ind - 1].get_end_pos();
+
+    Ok(Box::new(ASTTreeNode::new(
+        ASTTreeNodeKind::RangedForBlock { var, range, body },
+        start,
+        end,
+    )))
 }

--- a/compiler/ast_parser/src/control/for_loop.rs
+++ b/compiler/ast_parser/src/control/for_loop.rs
@@ -25,7 +25,7 @@ pub fn parse_for_loop(
 
     tokens[*ind].expects(LexerTokenType::Var)?;
 
-    let initial = parse_variable_declaration(tokens, ind)?;
+    let initial = parse_variable_declaration(tokens, ind, true)?;
 
     tokens[*ind].expects(LexerTokenType::Comma)?;
 
@@ -64,7 +64,7 @@ pub fn parse_for_ranged_loop(
 ) -> DiagnosticResult<Box<ASTTreeNode>> {
     let start = tokens[*ind].pos.clone();
 
-    let var = parse_variable_declaration(tokens, ind)?;
+    let var = parse_variable_declaration(tokens, ind, false)?;
 
     tokens[*ind].expects(LexerTokenType::EqualSign)?;
     *ind += 1;
@@ -75,11 +75,10 @@ pub fn parse_for_ranged_loop(
     let range = parse_value_range(tokens, ind)?;
 
     tokens[*ind].expects(LexerTokenType::BracketOpen)?;
-    *ind += 1;
 
     let body = parse_node_body(tokens, ind)?;
 
-    let end = tokens[*ind - 1].get_end_pos();
+    let end: compiler_utils::Position = tokens[*ind - 1].get_end_pos();
 
     Ok(Box::new(ASTTreeNode::new(
         ASTTreeNodeKind::RangedForBlock { var, range, body },

--- a/compiler/ast_parser/src/functions/mod.rs
+++ b/compiler/ast_parser/src/functions/mod.rs
@@ -123,22 +123,8 @@ pub fn parse_node_body(
     let mut tok: &LexerToken = &tokens[*ind];
     let mut body: Vec<Box<ASTTreeNode>> = Vec::new();
 
-    let mut stock = 1;
-
     while tok.tok_type != LexerTokenType::EndOfFile && tok.tok_type != LexerTokenType::BracketClose
     {
-        if tok.tok_type == LexerTokenType::BracketClose {
-            stock -= 1;
-        }
-
-        if stock == 0 {
-            break;
-        }
-
-        if tok.tok_type == LexerTokenType::BracketOpen {
-            stock += 1;
-        }
-
         let n = parse_ast_node_in_body(tokens, ind)?;
 
         body.push(n);

--- a/compiler/ast_parser/src/functions/mod.rs
+++ b/compiler/ast_parser/src/functions/mod.rs
@@ -31,8 +31,6 @@ pub fn parse_function_return_type(
 
         return Ok(Some(ty));
     } else {
-        *ind += 1;
-
         return Ok(None);
     }
 }

--- a/compiler/ast_parser/src/functions/mod.rs
+++ b/compiler/ast_parser/src/functions/mod.rs
@@ -125,6 +125,13 @@ pub fn parse_node_body(
 
     while tok.tok_type != LexerTokenType::EndOfFile && tok.tok_type != LexerTokenType::BracketClose
     {
+        if tok.tok_type == LexerTokenType::SemiCollon {
+            *ind += 1;
+            tok = &tokens[*ind];
+
+            continue;
+        }
+
         let n = parse_ast_node_in_body(tokens, ind)?;
 
         body.push(n);

--- a/compiler/ast_parser/src/functions/mod.rs
+++ b/compiler/ast_parser/src/functions/mod.rs
@@ -17,6 +17,26 @@ pub mod arguments;
 pub mod returns;
 pub mod shadow;
 
+pub fn parse_function_return_type(
+    tokens: &Vec<LexerToken>,
+    ind: &mut usize,
+) -> DiagnosticResult<Option<ASTType>> {
+    if tokens[*ind].tok_type == LexerTokenType::Minus {
+        *ind += 1;
+
+        tokens[*ind].expects(LexerTokenType::AngelBracketClose)?;
+        *ind += 1;
+
+        let ty = parse_type(tokens, ind)?;
+
+        return Ok(Some(ty));
+    } else {
+        *ind += 1;
+
+        return Ok(None);
+    }
+}
+
 pub fn parse_function_declaraction(
     tokens: &Vec<LexerToken>,
     ind: &mut usize,
@@ -34,12 +54,7 @@ pub fn parse_function_declaraction(
 
     *ind += 1;
 
-    let mut ret_type = None;
-
-    if tokens[*ind].is_keyword() {
-        ret_type = Some(parse_type(tokens, ind)?);
-        //*ind += 1;
-    }
+    let ret_type = parse_function_return_type(tokens, ind)?;
 
     tokens[*ind].expects(LexerTokenType::BracketOpen)?;
 

--- a/compiler/ast_parser/src/functions/shadow.rs
+++ b/compiler/ast_parser/src/functions/shadow.rs
@@ -7,7 +7,7 @@ use lexer::token::{LexerToken, LexerTokenType};
 
 use crate::{functions::arguments::parse_function_arguments, types::parse_type};
 
-pub fn parse_shadow_function_declaration(
+pub fn parse_extern_function_definition(
     tokens: &Vec<LexerToken>,
     ind: &mut usize,
 ) -> DiagnosticResult<Box<ASTTreeNode>> {
@@ -35,7 +35,7 @@ pub fn parse_shadow_function_declaration(
     }
 
     return Ok(Box::new(ASTTreeNode::new(
-        ASTTreeNodeKind::ShadowFunctionDeclaration {
+        ASTTreeNodeKind::ExternFunctionDeclaration {
             func_name: HashedString::new(function_name.0),
             args: args.0,
             return_type: ret_type,

--- a/compiler/ast_parser/src/functions/shadow.rs
+++ b/compiler/ast_parser/src/functions/shadow.rs
@@ -5,7 +5,7 @@ use compiler_utils::hash::HashedString;
 use diagnostics::DiagnosticResult;
 use lexer::token::{LexerToken, LexerTokenType};
 
-use crate::{functions::arguments::parse_function_arguments, types::parse_type};
+use crate::functions::{arguments::parse_function_arguments, parse_function_return_type};
 
 pub fn parse_extern_function_definition(
     tokens: &Vec<LexerToken>,
@@ -23,16 +23,8 @@ pub fn parse_extern_function_definition(
 
     *ind += 1;
 
-    let mut ret_type = None;
-    let end;
-
-    if tokens[*ind].is_keyword() {
-        ret_type = Some(parse_type(tokens, ind)?);
-
-        end = tokens[*ind].get_end_pos().clone();
-    } else {
-        end = tokens[*ind - 1].get_end_pos().clone();
-    }
+    let ret_type = parse_function_return_type(tokens, ind)?;
+    let end = tokens[*ind].get_end_pos();
 
     return Ok(Box::new(ASTTreeNode::new(
         ASTTreeNodeKind::ExternFunctionDeclaration {

--- a/compiler/ast_parser/src/lib.rs
+++ b/compiler/ast_parser/src/lib.rs
@@ -15,6 +15,7 @@ pub mod functions;
 pub mod literals;
 pub mod math;
 pub mod parser;
+pub mod ranges;
 pub mod structs;
 pub mod types;
 pub mod unwraps;

--- a/compiler/ast_parser/src/lib.rs
+++ b/compiler/ast_parser/src/lib.rs
@@ -15,6 +15,7 @@ pub mod functions;
 pub mod literals;
 pub mod math;
 pub mod parser;
+pub mod pointers;
 pub mod ranges;
 pub mod structs;
 pub mod types;

--- a/compiler/ast_parser/src/math.rs
+++ b/compiler/ast_parser/src/math.rs
@@ -31,8 +31,6 @@ pub fn parse_math_operation(
             .into());
     }
 
-    println!("{:#?}", tokens[*ind].tok_type);
-
     let right_member = parse_ast_value(tokens, ind)?;
 
     let start = original.start.clone();

--- a/compiler/ast_parser/src/parser.rs
+++ b/compiler/ast_parser/src/parser.rs
@@ -76,7 +76,7 @@ pub fn parse_ast_node_in_body(
 ) -> DiagnosticResult<Box<ASTTreeNode>> {
     match &tokens[*ind].tok_type {
         LexerTokenType::Var => {
-            return parse_variable_declaration(tokens, ind);
+            return parse_variable_declaration(tokens, ind, true);
         }
 
         LexerTokenType::If => {

--- a/compiler/ast_parser/src/parser.rs
+++ b/compiler/ast_parser/src/parser.rs
@@ -101,6 +101,7 @@ pub fn parse_ast_node_in_body(
         LexerTokenType::Keyword(str, _) => {
             if tokens[*ind + 1].tok_type == LexerTokenType::ParenOpen {
                 let call = parse_function_call(tokens, ind);
+
                 return parse_ast_value_post_l(tokens, ind, call, true);
             }
 

--- a/compiler/ast_parser/src/parser.rs
+++ b/compiler/ast_parser/src/parser.rs
@@ -17,6 +17,7 @@ use crate::{
         parse_function_call, parse_function_declaraction, returns::parse_function_return_statement,
         shadow::parse_extern_function_definition,
     },
+    pointers::parse_deref_modify,
     structs::{enums::parse_enum_declaration, parse_type_declaration},
     use_statements::parse_use_statement,
     value::parse_ast_value_post_l,
@@ -90,6 +91,8 @@ pub fn parse_ast_node_in_body(
         LexerTokenType::For => {
             return parse_for_loop(tokens, ind);
         }
+
+        LexerTokenType::Asterisk => return parse_deref_modify(tokens, ind),
 
         LexerTokenType::Return => {
             return parse_function_return_statement(tokens, ind);

--- a/compiler/ast_parser/src/parser.rs
+++ b/compiler/ast_parser/src/parser.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     functions::{
         parse_function_call, parse_function_declaraction, returns::parse_function_return_statement,
-        shadow::parse_shadow_function_declaration,
+        shadow::parse_extern_function_definition,
     },
     structs::{enums::parse_enum_declaration, parse_type_declaration},
     use_statements::parse_use_statement,
@@ -39,8 +39,8 @@ pub fn parse_ast_node(
             return parse_function_declaraction(tokens, ind, None);
         }
 
-        LexerTokenType::ShadowFunction => {
-            return parse_shadow_function_declaration(tokens, ind);
+        LexerTokenType::ExternFunc => {
+            return parse_extern_function_definition(tokens, ind);
         }
 
         LexerTokenType::Struct => {

--- a/compiler/ast_parser/src/pointers.rs
+++ b/compiler/ast_parser/src/pointers.rs
@@ -1,8 +1,8 @@
 use ast::tree::{ASTTreeNode, ASTTreeNodeKind};
 use diagnostics::DiagnosticResult;
-use lexer::token::LexerToken;
+use lexer::token::{LexerToken, LexerTokenType};
 
-use crate::value::{parse_ast_value_full, parse_ast_value_post_l};
+use crate::value::{parse_ast_value, parse_ast_value_full};
 
 pub fn parse_deref_modify(
     tokens: &Vec<LexerToken>,
@@ -10,15 +10,21 @@ pub fn parse_deref_modify(
 ) -> DiagnosticResult<Box<ASTTreeNode>> {
     *ind += 1; // *
 
-    let val = parse_ast_value_full(tokens, ind, false)?;
+    let pointer = parse_ast_value_full(tokens, ind, false)?;
+
+    tokens[*ind].expects(LexerTokenType::EqualSign)?;
+    *ind += 1; // =
+
+    let val = parse_ast_value(tokens, ind)?;
 
     let deref = Box::new(ASTTreeNode::new(
         ASTTreeNodeKind::DereferenceModify {
-            pointer: val.clone(),
+            pointer,
+            val: val.clone(),
         },
         val.start.clone(),
         val.end,
     ));
 
-    parse_ast_value_post_l(tokens, ind, Ok(deref), false)
+    Ok(deref)
 }

--- a/compiler/ast_parser/src/pointers.rs
+++ b/compiler/ast_parser/src/pointers.rs
@@ -1,0 +1,24 @@
+use ast::tree::{ASTTreeNode, ASTTreeNodeKind};
+use diagnostics::DiagnosticResult;
+use lexer::token::LexerToken;
+
+use crate::value::{parse_ast_value_full, parse_ast_value_post_l};
+
+pub fn parse_deref_modify(
+    tokens: &Vec<LexerToken>,
+    ind: &mut usize,
+) -> DiagnosticResult<Box<ASTTreeNode>> {
+    *ind += 1; // *
+
+    let val = parse_ast_value_full(tokens, ind, false)?;
+
+    let deref = Box::new(ASTTreeNode::new(
+        ASTTreeNodeKind::DereferenceModify {
+            pointer: val.clone(),
+        },
+        val.start.clone(),
+        val.end,
+    ));
+
+    parse_ast_value_post_l(tokens, ind, Ok(deref), false)
+}

--- a/compiler/ast_parser/src/ranges.rs
+++ b/compiler/ast_parser/src/ranges.rs
@@ -1,0 +1,50 @@
+use ast::{
+    ranges::ASTRange,
+    tree::{ASTTreeNode, ASTTreeNodeKind},
+};
+use compiler_utils::hash;
+use diagnostics::DiagnosticResult;
+use lexer::token::{LexerToken, LexerTokenType};
+
+use crate::value::parse_ast_value;
+
+pub fn parse_value_range(tokens: &Vec<LexerToken>, ind: &mut usize) -> DiagnosticResult<ASTRange> {
+    tokens[*ind].expects(LexerTokenType::ArrayOpen)?;
+    *ind += 1;
+
+    let min;
+    let mut got_first_dot = false;
+
+    if tokens[*ind].tok_type == LexerTokenType::Dot {
+        min = Box::new(ASTTreeNode::new(
+            ASTTreeNodeKind::IntegerLit {
+                val: 0,
+                hash: hash!("s64"),
+            },
+            tokens[*ind].pos.clone(),
+            tokens[*ind].get_end_pos(),
+        ));
+
+        got_first_dot = true;
+
+        *ind += 1;
+    } else {
+        min = parse_ast_value(tokens, ind)?;
+    }
+
+    tokens[*ind].expects(LexerTokenType::Dot)?;
+    *ind += 1;
+
+    if !got_first_dot {
+        tokens[*ind].expects(LexerTokenType::Dot)?;
+        *ind += 1;
+    }
+
+    let max = parse_ast_value(tokens, ind)?;
+
+    tokens[*ind].expects(LexerTokenType::ArrayClose)?;
+
+    *ind += 1;
+
+    Ok(ASTRange { min, max })
+}

--- a/compiler/ast_parser/src/use_statements.rs
+++ b/compiler/ast_parser/src/use_statements.rs
@@ -22,6 +22,9 @@ pub fn parse_use_statement(
 
         tokens[*ind].expects(LexerTokenType::Collon)?;
         *ind += 1;
+
+        tokens[*ind].expects(LexerTokenType::Collon)?;
+        *ind += 1;
     }
 
     tokens[*ind].expects(LexerTokenType::ArrayOpen)?;

--- a/compiler/ast_parser/src/value.rs
+++ b/compiler/ast_parser/src/value.rs
@@ -125,10 +125,14 @@ pub fn parse_ast_value_post_l(
         | LexerTokenType::Minus
         | LexerTokenType::Asterisk
         | LexerTokenType::Divide => {
-            let o = &original?;
+            let o = &original.clone()?;
             let k = Box::new(ASTTreeNode::clone(o.as_ref()));
 
-            return Ok(parse_math_operation(tokens, ind, k, invoked_on_body)?);
+            if !invoked_on_body {
+                return Ok(parse_math_operation(tokens, ind, k, invoked_on_body)?);
+            } else {
+                return original;
+            }
         }
 
         LexerTokenType::ArrayOpen => {

--- a/compiler/ast_parser/src/value.rs
+++ b/compiler/ast_parser/src/value.rs
@@ -160,21 +160,6 @@ pub fn parse_ast_value_post_l(
 
                     return Ok(Box::new(ASTTreeNode::new(kind, start, end)));
                 }
-
-                if let ASTTreeNodeKind::Dereference(inner) = &v.kind {
-                    let start = original.clone()?.start.clone();
-
-                    let right_val = parse_ast_value(tokens, ind)?;
-
-                    let end = right_val.end.clone();
-
-                    let kind = ASTTreeNodeKind::DereferenceModify {
-                        pointer: inner.clone(),
-                        new_value: right_val,
-                    };
-
-                    return Ok(Box::new(ASTTreeNode::new(kind, start, end)));
-                }
             }
 
             let start = original.clone()?.start.clone();
@@ -230,14 +215,23 @@ pub fn parse_ast_condition_if_statement_value(
 /// - Math operation results (both with or without value changing)
 /// - Boolean negation result
 /// - Boolean compare result
+
 pub fn parse_ast_value(
     tokens: &Vec<LexerToken>,
     ind: &mut usize,
 ) -> DiagnosticResult<Box<ASTTreeNode>> {
+    parse_ast_value_full(tokens, ind, true)
+}
+
+pub fn parse_ast_value_full(
+    tokens: &Vec<LexerToken>,
+    ind: &mut usize,
+    allow_lparsing: bool,
+) -> DiagnosticResult<Box<ASTTreeNode>> {
     match &tokens[*ind].tok_type {
         LexerTokenType::ExclamationMark => {
             *ind += 1;
-            let ast = parse_ast_value(tokens, ind)?;
+            let ast = parse_ast_value_full(tokens, ind, allow_lparsing)?;
 
             if ast.kind.is_function_call() || ast.kind.is_var_access() {
                 let end = ast.end.clone();
@@ -268,12 +262,22 @@ pub fn parse_ast_value(
 
         LexerTokenType::IntLit(_, _) => {
             let int = parse_integer_literal(tokens, ind);
-            return parse_ast_value_post_l(tokens, ind, int, false);
+
+            if allow_lparsing {
+                return parse_ast_value_post_l(tokens, ind, int, false);
+            } else {
+                return int;
+            }
         }
 
         LexerTokenType::StringLit(_) => {
             let str = parse_string_literal(tokens, ind);
-            return parse_ast_value_post_l(tokens, ind, str, false);
+
+            if allow_lparsing {
+                return parse_ast_value_post_l(tokens, ind, str, false);
+            } else {
+                return str;
+            }
         }
 
         LexerTokenType::BracketOpen => {
@@ -283,7 +287,12 @@ pub fn parse_ast_value(
         LexerTokenType::Keyword(str, _) => {
             if tokens[*ind + 1].tok_type == LexerTokenType::ParenOpen {
                 let call = parse_function_call(tokens, ind);
-                return parse_ast_value_post_l(tokens, ind, call, false);
+
+                if allow_lparsing {
+                    return parse_ast_value_post_l(tokens, ind, call, false);
+                } else {
+                    return call;
+                }
             }
 
             let n = Ok(make_node!(
@@ -296,7 +305,11 @@ pub fn parse_ast_value(
 
             let chain = parse_ast_value_dotacess(tokens, ind, n);
 
-            return parse_ast_value_post_l(tokens, ind, chain, false);
+            if allow_lparsing {
+                return parse_ast_value_post_l(tokens, ind, chain, false);
+            } else {
+                return chain;
+            }
         }
 
         LexerTokenType::Unwrap | LexerTokenType::UnwrapUnsafe => parse_unwrap_value(tokens, ind),

--- a/compiler/ast_parser/src/value.rs
+++ b/compiler/ast_parser/src/value.rs
@@ -160,6 +160,21 @@ pub fn parse_ast_value_post_l(
 
                     return Ok(Box::new(ASTTreeNode::new(kind, start, end)));
                 }
+
+                if let ASTTreeNodeKind::Dereference(inner) = &v.kind {
+                    let start = original.clone()?.start.clone();
+
+                    let right_val = parse_ast_value(tokens, ind)?;
+
+                    let end = right_val.end.clone();
+
+                    let kind = ASTTreeNodeKind::DereferenceModify {
+                        pointer: inner.clone(),
+                        new_value: right_val,
+                    };
+
+                    return Ok(Box::new(ASTTreeNode::new(kind, start, end)));
+                }
             }
 
             let start = original.clone()?.start.clone();
@@ -248,7 +263,7 @@ pub fn parse_ast_value(
             return parse_ast_array_init(tokens, ind);
         }
 
-        LexerTokenType::Asterisk => return parse_ast_pointer(tokens, ind),
+        LexerTokenType::Asterisk => return parse_ast_dereference(tokens, ind),
         LexerTokenType::Ampersand => return parse_ast_reference(tokens, ind),
 
         LexerTokenType::IntLit(_, _) => {
@@ -339,7 +354,7 @@ pub fn parse_ast_array_init(
     )));
 }
 
-pub fn parse_ast_pointer(
+pub fn parse_ast_dereference(
     tokens: &Vec<LexerToken>,
     ind: &mut usize,
 ) -> DiagnosticResult<Box<ASTTreeNode>> {
@@ -351,7 +366,7 @@ pub fn parse_ast_pointer(
     let value = parse_ast_value(tokens, ind)?;
 
     return Ok(Box::new(ASTTreeNode::new(
-        ASTTreeNodeKind::PointerGrab(value),
+        ASTTreeNodeKind::Dereference(value),
         start,
         tokens[*ind].get_end_pos(),
     )));

--- a/compiler/ast_parser/src/variables/decl.rs
+++ b/compiler/ast_parser/src/variables/decl.rs
@@ -9,6 +9,7 @@ use crate::{types::parse_type, value::parse_ast_value};
 pub fn parse_variable_declaration(
     tokens: &Vec<LexerToken>,
     ind: &mut usize,
+    allow_value: bool,
 ) -> DiagnosticResult<Box<ASTTreeNode>> {
     let start = tokens[*ind].pos.clone();
 
@@ -23,7 +24,7 @@ pub fn parse_variable_declaration(
     let mut val: Option<Box<ASTTreeNode>> = None;
     let end;
 
-    if tokens[*ind].tok_type == LexerTokenType::EqualSign {
+    if tokens[*ind].tok_type == LexerTokenType::EqualSign && allow_value {
         *ind += 1;
 
         val = Some(parse_ast_value(tokens, ind)?);

--- a/compiler/astoir_hir/src/ctx.rs
+++ b/compiler/astoir_hir/src/ctx.rs
@@ -30,14 +30,13 @@ pub type HIRFunctionImpl = Box<HIRNode>;
 /// Every variable has a specific branch period called era in which they are allowed to live in. An era can simply be defined as a branch index.
 ///
 /// Every branch index stores an end branch index from when it ends (inside of `ending_eras`). This end branch index will be used to calculate when the era of a variable ends.
-///
-///
 #[derive(Debug, Clone)]
 pub struct HIRBranchedContext {
     pub hash_to_ind: HashMap<SelfHash, usize>, // TODO: add a layer system to this so you are able to put multiple variables with the same name.
     pub ending_eras: HashMap<usize, usize>,
 
     pub variables: Vec<HIRBranchedVariable>, // index is the resolved indec
+    pub ending_points: Vec<HIRBranchedEndingPoint>,
 
     pub return_type: Option<Type>,
 
@@ -45,12 +44,26 @@ pub struct HIRBranchedContext {
     pub current_element_index: usize,
 }
 
+#[derive(Debug, Clone)]
+pub struct HIRBranchedEndingPoint {
+    pub introduced_in_era: usize,
+    pub kind: EndingPointKind,
+}
+
+#[derive(Debug, Clone)]
+pub enum EndingPointKind {
+    Return,
+    Crash,
+    NoneReturn,
+}
+
 impl HIRBranchedContext {
     pub fn new(return_type: Option<Type>) -> Self {
         HIRBranchedContext {
             hash_to_ind: HashMap::new(),
             ending_eras: HashMap::new(),
-            variables: Vec::new(),
+            ending_points: vec![],
+            variables: vec![],
             return_type,
             current_branch: 0,
             current_element_index: 0,

--- a/compiler/astoir_hir/src/ctx.rs
+++ b/compiler/astoir_hir/src/ctx.rs
@@ -175,7 +175,7 @@ impl HIRBranchedContext {
     pub fn is_alive(&self, ind: usize) -> bool {
         let start_branch = self.variables[ind].introduced_in_era;
 
-        if start_branch > self.current_element_index {
+        if start_branch > self.current_branch {
             return false;
         }
 
@@ -240,7 +240,13 @@ impl HIRBranchedContext {
                         return Err(make_doesnt_exist_in_era(origin, &hash).into());
                     }
 
-                    panic!("Dropped unalived variable")
+                    println!(
+                        "Variable dropped before! Information dump: introduced {}, ending era {}",
+                        self.variables[ind].introduced_in_era,
+                        self.ending_eras[&self.variables[ind].introduced_in_era]
+                    );
+
+                    panic!("Dropped unalived variable {} -> hash {}", ind, hash);
                 }
 
                 self.variables[ind].usage_count += 1;

--- a/compiler/astoir_hir/src/ctx.rs
+++ b/compiler/astoir_hir/src/ctx.rs
@@ -184,6 +184,13 @@ impl HIRBranchedContext {
         return true;
     }
 
+    pub fn introduce_ending_point(&mut self, kind: EndingPointKind) {
+        self.ending_points.push(HIRBranchedEndingPoint {
+            introduced_in_era: self.current_branch,
+            kind,
+        })
+    }
+
     /// Determines if the element with the given index is still alive in the current branch.
     pub fn is_alive(&self, ind: usize) -> bool {
         let start_branch = self.variables[ind].introduced_in_era;
@@ -215,7 +222,7 @@ impl HIRBranchedContext {
     /// Determines if the current function meets the ending point requirement.
     /// The requirement is that every single branch should have an ending point that affects it.
     /// This function uses `is_code_alive` to check if the code ended on each branch before the current branch.
-	/// This function should only be ran at the end of body parsing
+    /// This function should only be ran at the end of body parsing
     pub fn meets_ending_point(&self) -> bool {
         if !self.is_code_alive(self.current_branch) {
             return true;

--- a/compiler/astoir_hir/src/ctx.rs
+++ b/compiler/astoir_hir/src/ctx.rs
@@ -195,6 +195,41 @@ impl HIRBranchedContext {
         return self.is_era_alive(start_branch);
     }
 
+    /// Checks if the code is currently alive on the given branch. Alive meaning before an ending point has taken effect.
+    /// This function can also be used to detect unreachable code by using this function on the current branch
+    pub fn is_code_alive(&self, branch: usize) -> bool {
+        for ending in &self.ending_points {
+            let end = match self.ending_eras.get(&ending.introduced_in_era) {
+                Some(v) => *v,
+                None => ending.introduced_in_era,
+            };
+
+            if branch >= end {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    /// Determines if the current function meets the ending point requirement.
+    /// The requirement is that every single branch should have an ending point that affects it.
+    /// This function uses `is_code_alive` to check if the code ended on each branch before the current branch.
+	/// This function should only be ran at the end of body parsing
+    pub fn meets_ending_point(&self) -> bool {
+        if !self.is_code_alive(self.current_branch) {
+            return true;
+        }
+
+        for i in 0..self.current_branch {
+            if self.is_code_alive(i) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     pub fn is_era_alive(&self, era: usize) -> bool {
         if !self.ending_eras.contains_key(&era) {
             // If the era hasn't ended yet, (the ending era isn't added for branch start_branch)

--- a/compiler/astoir_hir/src/ctx.rs
+++ b/compiler/astoir_hir/src/ctx.rs
@@ -262,7 +262,7 @@ impl HIRBranchedContext {
         return !var.requires_address
             && var.mutation_count <= 1
             && !var.variable_type.can_use_index_access()
-            && false;
+            && !var.variable_type.is_struct();
     }
 }
 

--- a/compiler/astoir_hir/src/ctx.rs
+++ b/compiler/astoir_hir/src/ctx.rs
@@ -39,16 +39,19 @@ pub struct HIRBranchedContext {
 
     pub variables: Vec<HIRBranchedVariable>, // index is the resolved indec
 
+    pub return_type: Option<Type>,
+
     pub current_branch: usize,
     pub current_element_index: usize,
 }
 
 impl HIRBranchedContext {
-    pub fn new() -> Self {
+    pub fn new(return_type: Option<Type>) -> Self {
         HIRBranchedContext {
             hash_to_ind: HashMap::new(),
             ending_eras: HashMap::new(),
             variables: Vec::new(),
+            return_type,
             current_branch: 0,
             current_element_index: 0,
         }

--- a/compiler/astoir_hir/src/nodes.rs
+++ b/compiler/astoir_hir/src/nodes.rs
@@ -129,7 +129,12 @@ pub enum HIRNodeKind {
         index: usize,
     },
 
-    PointerGrab {
+    DereferenceModify {
+        pointer: Box<HIRNode>,
+        val: Box<HIRNode>,
+    },
+
+    Dereference {
         val: Box<HIRNode>,
     },
     ReferenceGrab {
@@ -430,17 +435,21 @@ impl HIRNode {
                 return Some(curr_ctx.variables[*index].variable_type.clone());
             }
 
-            HIRNodeKind::PointerGrab { val } => {
+            HIRNodeKind::Dereference { val } => {
+                let ty = val.get_node_type(context, curr_ctx).unwrap();
+
+                if ty.is_generic_direct() {
+                    None
+                } else {
+                    Some(*ty.get_inner_type())
+                }
+            }
+
+            HIRNodeKind::ReferenceGrab { val } => {
                 return Some(Type::Pointer(
                     false,
                     Box::new(val.get_node_type(context, curr_ctx).unwrap()),
                 ));
-            }
-
-            HIRNodeKind::ReferenceGrab { val } => {
-                return Some(Type::Reference(Box::new(
-                    val.get_node_type(context, curr_ctx).unwrap(),
-                )));
             }
 
             HIRNodeKind::UnwrapCondition { .. } => {

--- a/compiler/astoir_hir/src/nodes.rs
+++ b/compiler/astoir_hir/src/nodes.rs
@@ -201,7 +201,7 @@ pub enum HIRNodeKind {
         requires_this: bool,
     },
 
-    ShadowFunctionDeclaration {
+    ExternFunctionDeclaration {
         func_name: usize,
         arguments: Vec<(u64, Type)>,
         return_type: Option<Type>,

--- a/compiler/astoir_hir/src/nodes.rs
+++ b/compiler/astoir_hir/src/nodes.rs
@@ -21,7 +21,7 @@ use diagnostics::{
 use crate::{
     ctx::{HIRBranchedContext, HIRContext},
     resolve::resolve_to_type,
-    structs::{HIRIfBranch, StructLRUStep},
+    structs::{HIRIfBranch, HIRRange, StructLRUStep},
 };
 
 #[derive(Debug, Clone)]
@@ -220,6 +220,12 @@ pub enum HIRNodeKind {
         initial_state: Box<HIRNode>,
         condition: Box<HIRNode>,
         incrementation: Box<HIRNode>,
+        body: Vec<Box<HIRNode>>,
+    },
+
+    RangedForBlock {
+        variable: Box<HIRNode>,
+        range: HIRRange,
         body: Vec<Box<HIRNode>>,
     },
 

--- a/compiler/astoir_hir/src/nodes.rs
+++ b/compiler/astoir_hir/src/nodes.rs
@@ -270,6 +270,13 @@ impl HIRNode {
         return false;
     }
 
+    pub fn is_ending_point(&self) -> bool {
+        match self.kind {
+            HIRNodeKind::ReturnStatement { .. } => true,
+            _ => false,
+        }
+    }
+
     pub fn get_variable_represent(&self) -> (usize, bool) {
         match &self.kind {
             HIRNodeKind::VariableReference { index, is_static } => return (*index, *is_static),

--- a/compiler/astoir_hir/src/structs.rs
+++ b/compiler/astoir_hir/src/structs.rs
@@ -28,6 +28,12 @@ pub enum HIRIfBranch {
     },
 }
 
+#[derive(Clone, Debug)]
+pub struct HIRRange {
+    pub min: Box<HIRNode>,
+    pub max: Box<HIRNode>,
+}
+
 #[derive(Debug)]
 pub struct HIRStructContainer {
     pub function_impls: Vec<Box<HIRNode>>,

--- a/compiler/astoir_hir_lowering/src/control.rs
+++ b/compiler/astoir_hir_lowering/src/control.rs
@@ -26,7 +26,8 @@ pub fn lower_ast_for_block(
     {
         let branch = curr_ctx.start_branch();
 
-        let initial = lower_ast_variable_declaration(context, curr_ctx, initial_state, false)?;
+        let initial =
+            lower_ast_variable_declaration(context, curr_ctx, initial_state, false, None)?;
         let condition = lower_ast_condition(context, curr_ctx, cond)?;
 
         let incrementation = lower_ast_math_operation(context, curr_ctx, increment, true)?;
@@ -58,14 +59,12 @@ pub fn lower_ast_for_ranged_block(
     if let ASTTreeNodeKind::RangedForBlock { var, range, body } = node.kind.clone() {
         let branch = curr_ctx.start_branch();
 
-        let initial = lower_ast_variable_declaration(context, curr_ctx, var, true)?;
-        let range = lower_ast_range(
-            context,
-            curr_ctx,
-            range,
-            Type::Generic(RawType::Integer(64, false), vec![], vec![]),
-            &*node,
-        )?;
+        let ty = Type::Generic(RawType::Integer(64, false), vec![], vec![]);
+
+        let initial =
+            lower_ast_variable_declaration(context, curr_ctx, var, true, Some(ty.clone()))?;
+
+        let range = lower_ast_range(context, curr_ctx, range, ty, &*node)?;
         let body = lower_ast_body(context, curr_ctx, body, false)?;
 
         curr_ctx.end_branch(branch);

--- a/compiler/astoir_hir_lowering/src/control.rs
+++ b/compiler/astoir_hir_lowering/src/control.rs
@@ -8,7 +8,7 @@ use diagnostics::DiagnosticResult;
 
 use crate::{
     bools::lower_ast_condition, lower_ast_body, math::lower_ast_math_operation,
-    var::lower_ast_variable_declaration,
+    values::lower_ast_range, var::lower_ast_variable_declaration,
 };
 
 pub fn lower_ast_for_block(
@@ -25,7 +25,7 @@ pub fn lower_ast_for_block(
     {
         let branch = curr_ctx.start_branch();
 
-        let initial = lower_ast_variable_declaration(context, curr_ctx, initial_state)?;
+        let initial = lower_ast_variable_declaration(context, curr_ctx, initial_state, false)?;
         let condition = lower_ast_condition(context, curr_ctx, cond)?;
 
         let incrementation = lower_ast_math_operation(context, curr_ctx, increment, true)?;
@@ -47,6 +47,34 @@ pub fn lower_ast_for_block(
     }
 
     panic!("Invalid node passed!");
+}
+
+pub fn lower_ast_for_ranged_block(
+    context: &mut HIRContext,
+    curr_ctx: &mut HIRBranchedContext,
+    node: Box<ASTTreeNode>,
+) -> DiagnosticResult<Box<HIRNode>> {
+    if let ASTTreeNodeKind::RangedForBlock { var, range, body } = node.kind.clone() {
+        let branch = curr_ctx.start_branch();
+
+        let initial = lower_ast_variable_declaration(context, curr_ctx, var, true)?;
+        let range = lower_ast_range(context, curr_ctx, range)?;
+        let body = lower_ast_body(context, curr_ctx, body, false)?;
+
+        curr_ctx.end_branch(branch);
+
+        return Ok(Box::new(HIRNode::new(
+            HIRNodeKind::RangedForBlock {
+                variable: initial,
+                range,
+                body,
+            },
+            &node.start,
+            &node.end,
+        )));
+    }
+
+    panic!("Invalid node!")
 }
 
 pub fn lower_ast_while_block(

--- a/compiler/astoir_hir_lowering/src/control.rs
+++ b/compiler/astoir_hir_lowering/src/control.rs
@@ -4,6 +4,7 @@ use astoir_hir::{
     nodes::{HIRNode, HIRNodeKind},
     structs::HIRIfBranch,
 };
+use compiler_typing::{raw::RawType, tree::Type};
 use diagnostics::DiagnosticResult;
 
 use crate::{
@@ -58,7 +59,13 @@ pub fn lower_ast_for_ranged_block(
         let branch = curr_ctx.start_branch();
 
         let initial = lower_ast_variable_declaration(context, curr_ctx, var, true)?;
-        let range = lower_ast_range(context, curr_ctx, range)?;
+        let range = lower_ast_range(
+            context,
+            curr_ctx,
+            range,
+            Type::Generic(RawType::Integer(64, false), vec![], vec![]),
+            &*node,
+        )?;
         let body = lower_ast_body(context, curr_ctx, body, false)?;
 
         curr_ctx.end_branch(branch);

--- a/compiler/astoir_hir_lowering/src/func.rs
+++ b/compiler/astoir_hir_lowering/src/func.rs
@@ -83,7 +83,7 @@ pub fn lower_ast_function_declaration(
             arguments.push((arg.name.hash, t));
         }
 
-        let mut curr_ctx = HIRBranchedContext::new();
+        let mut curr_ctx = HIRBranchedContext::new(ret_type.clone());
 
         let branch = curr_ctx.start_branch();
 

--- a/compiler/astoir_hir_lowering/src/func.rs
+++ b/compiler/astoir_hir_lowering/src/func.rs
@@ -115,12 +115,6 @@ pub fn lower_ast_function_declaration(
 
         curr_ctx.end_branch(branch);
 
-        for var in 0..curr_ctx.variables.len() {
-            if curr_ctx.is_eligible_for_ssa(var) {
-                println!("* Function variable {} is eligible for SSA treatment!", var);
-            }
-        }
-
         let implementation = Box::new(HIRNode::new(
             HIRNodeKind::FunctionDeclaration {
                 func_name: ind,

--- a/compiler/astoir_hir_lowering/src/func.rs
+++ b/compiler/astoir_hir_lowering/src/func.rs
@@ -5,7 +5,10 @@ use astoir_hir::{
 };
 use compiler_global_scope::key::EntryKey;
 use compiler_typing::TypedGlobalScopeEntry;
-use diagnostics::{DiagnosticResult, builders::make_already_in_scope};
+use diagnostics::{
+    DiagnosticResult,
+    builders::{make_already_in_scope, make_ending_point_missing},
+};
 
 use crate::{lower_ast_body, types::lower_ast_type, values::lower_ast_value};
 
@@ -114,6 +117,10 @@ pub fn lower_ast_function_declaration(
         let body = lower_ast_body(context, &mut curr_ctx, body, false)?;
 
         curr_ctx.end_branch(branch);
+
+        if !curr_ctx.meets_ending_point() {
+            return Err(make_ending_point_missing(&*body[body.len() - 1]).into());
+        }
 
         let implementation = Box::new(HIRNode::new(
             HIRNodeKind::FunctionDeclaration {

--- a/compiler/astoir_hir_lowering/src/func.rs
+++ b/compiler/astoir_hir_lowering/src/func.rs
@@ -159,11 +159,11 @@ pub fn lower_ast_function_declaration(
     panic!("Invalid node passed!");
 }
 
-pub fn lower_ast_shadow_function_declaration(
+pub fn lower_ast_extern_function_declaration(
     context: &mut HIRContext,
     node: Box<ASTTreeNode>,
 ) -> DiagnosticResult<Box<HIRNode>> {
-    if let ASTTreeNodeKind::ShadowFunctionDeclaration {
+    if let ASTTreeNodeKind::ExternFunctionDeclaration {
         func_name,
         args,
         return_type,
@@ -198,7 +198,7 @@ pub fn lower_ast_shadow_function_declaration(
         )?;
 
         return Ok(Box::new(HIRNode::new(
-            HIRNodeKind::ShadowFunctionDeclaration {
+            HIRNodeKind::ExternFunctionDeclaration {
                 func_name: ind,
                 arguments,
                 return_type: ret_type,

--- a/compiler/astoir_hir_lowering/src/lib.rs
+++ b/compiler/astoir_hir_lowering/src/lib.rs
@@ -14,8 +14,8 @@ use crate::{
     control::{lower_ast_for_block, lower_ast_if_statement, lower_ast_while_block},
     enums::lower_ast_enum,
     func::{
-        lower_ast_function_call, lower_ast_function_declaration,
-        lower_ast_shadow_function_declaration,
+        lower_ast_extern_function_declaration, lower_ast_function_call,
+        lower_ast_function_declaration,
     },
     math::lower_ast_math_operation,
     structs::lower_ast_struct_declaration,
@@ -128,8 +128,8 @@ pub fn lower_ast_toplevel(
             return Ok(true);
         }
 
-        ASTTreeNodeKind::ShadowFunctionDeclaration { .. } => {
-            lower_ast_shadow_function_declaration(context, node)?;
+        ASTTreeNodeKind::ExternFunctionDeclaration { .. } => {
+            lower_ast_extern_function_declaration(context, node)?;
 
             return Ok(true);
         }

--- a/compiler/astoir_hir_lowering/src/lib.rs
+++ b/compiler/astoir_hir_lowering/src/lib.rs
@@ -11,7 +11,10 @@ use prelude::apply_prelude;
 
 use crate::{
     arrays::lower_ast_array_modify,
-    control::{lower_ast_for_block, lower_ast_if_statement, lower_ast_while_block},
+    control::{
+        lower_ast_for_block, lower_ast_for_ranged_block, lower_ast_if_statement,
+        lower_ast_while_block,
+    },
     enums::lower_ast_enum,
     func::{
         lower_ast_extern_function_declaration, lower_ast_function_call,
@@ -46,7 +49,7 @@ pub fn lower_ast_body_node(
     move_current_diagnostic_pos(node.get_pos());
     match node.kind.clone() {
         ASTTreeNodeKind::VarDeclaration { .. } => {
-            return lower_ast_variable_declaration(context, curr_ctx, node);
+            return lower_ast_variable_declaration(context, curr_ctx, node, false);
         }
         ASTTreeNodeKind::FunctionCall { .. } => {
             return lower_ast_function_call(context, curr_ctx, node);
@@ -68,7 +71,19 @@ pub fn lower_ast_body_node(
             if val.is_none() {
                 v = None;
             } else {
-                v = Some(lower_ast_value(context, curr_ctx, val.unwrap())?)
+                let mut k = lower_ast_value(context, curr_ctx, val.unwrap())?;
+
+                if curr_ctx.return_type.is_some() {
+                    k = Box::new(k.use_as(
+                        context,
+                        curr_ctx,
+                        curr_ctx.return_type.clone().unwrap(),
+                        &*node,
+                        None,
+                    )?);
+                }
+
+                v = Some(k)
             }
 
             return Ok(Box::new(HIRNode::new(
@@ -79,6 +94,9 @@ pub fn lower_ast_body_node(
         }
 
         ASTTreeNodeKind::ForBlock { .. } => return lower_ast_for_block(context, curr_ctx, node),
+        ASTTreeNodeKind::RangedForBlock { .. } => {
+            return lower_ast_for_ranged_block(context, curr_ctx, node);
+        }
         ASTTreeNodeKind::WhileBlock { .. } => {
             return lower_ast_while_block(context, curr_ctx, node);
         }

--- a/compiler/astoir_hir_lowering/src/lib.rs
+++ b/compiler/astoir_hir_lowering/src/lib.rs
@@ -23,7 +23,7 @@ use crate::{
     math::lower_ast_math_operation,
     structs::lower_ast_struct_declaration,
     uses::handle_ast_use_statement,
-    values::lower_ast_value,
+    values::{lower_ast_pointer_modify, lower_ast_value},
     var::{lower_ast_variable_assign, lower_ast_variable_declaration},
 };
 
@@ -102,6 +102,10 @@ pub fn lower_ast_body_node(
         }
         ASTTreeNodeKind::IfStatement { .. } => {
             return lower_ast_if_statement(context, curr_ctx, node);
+        }
+
+        ASTTreeNodeKind::DereferenceModify { .. } => {
+            return lower_ast_pointer_modify(context, curr_ctx, node);
         }
 
         _ => panic!("Invalid node type"),

--- a/compiler/astoir_hir_lowering/src/lib.rs
+++ b/compiler/astoir_hir_lowering/src/lib.rs
@@ -3,10 +3,14 @@ use ast::{
     tree::{ASTTreeNode, ASTTreeNodeKind},
 };
 use astoir_hir::{
-    ctx::{HIRBranchedContext, HIRContext},
+    ctx::{EndingPointKind, HIRBranchedContext, HIRContext},
     nodes::{HIRNode, HIRNodeKind},
 };
-use diagnostics::{DiagnosticResult, DiagnosticSpanOrigin, move_current_diagnostic_pos};
+use diagnostics::{
+    DiagnosticResult, DiagnosticSpanOrigin,
+    builders::{make_ret_type_kind, make_unreachable_code},
+    move_current_diagnostic_pos,
+};
 use prelude::apply_prelude;
 
 use crate::{
@@ -68,20 +72,24 @@ pub fn lower_ast_body_node(
         ASTTreeNodeKind::ReturnStatement { val } => {
             let v;
 
+            if val.is_none() != curr_ctx.return_type.is_none() {
+                return Err(make_ret_type_kind(&*node).into());
+            }
+
             if val.is_none() {
+                curr_ctx.introduce_ending_point(EndingPointKind::NoneReturn);
+
                 v = None;
             } else {
-                let mut k = lower_ast_value(context, curr_ctx, val.unwrap())?;
+                curr_ctx.introduce_ending_point(EndingPointKind::Return);
 
-                if curr_ctx.return_type.is_some() {
-                    k = Box::new(k.use_as(
-                        context,
-                        curr_ctx,
-                        curr_ctx.return_type.clone().unwrap(),
-                        &*node,
-                        None,
-                    )?);
-                }
+                let k = Box::new(lower_ast_value(context, curr_ctx, val.unwrap())?.use_as(
+                    context,
+                    curr_ctx,
+                    curr_ctx.return_type.clone().unwrap(),
+                    &*node,
+                    None,
+                )?);
 
                 v = Some(k)
             }
@@ -129,7 +137,17 @@ pub fn lower_ast_body(
     }
 
     for n in nodes {
-        hir_nodes.push(lower_ast_body_node(context, curr_ctx, n)?);
+        let is_code_dead_pre = !curr_ctx.is_code_alive(curr_ctx.current_branch);
+
+        let node = lower_ast_body_node(context, curr_ctx, n)?;
+
+        if !curr_ctx.is_code_alive(curr_ctx.current_branch) {
+            if is_code_dead_pre || !node.is_ending_point() {
+                return Err(make_unreachable_code(&*node).into());
+            }
+        }
+
+        hir_nodes.push(node);
     }
 
     if introduce_era {

--- a/compiler/astoir_hir_lowering/src/lib.rs
+++ b/compiler/astoir_hir_lowering/src/lib.rs
@@ -49,7 +49,7 @@ pub fn lower_ast_body_node(
     move_current_diagnostic_pos(node.get_pos());
     match node.kind.clone() {
         ASTTreeNodeKind::VarDeclaration { .. } => {
-            return lower_ast_variable_declaration(context, curr_ctx, node, false);
+            return lower_ast_variable_declaration(context, curr_ctx, node, false, None);
         }
         ASTTreeNodeKind::FunctionCall { .. } => {
             return lower_ast_function_call(context, curr_ctx, node);

--- a/compiler/astoir_hir_lowering/src/structs.rs
+++ b/compiler/astoir_hir_lowering/src/structs.rs
@@ -62,7 +62,7 @@ fn lower_ast_struct_function_decl(
             ret_type = None;
         }
 
-        let mut curr_ctx = HIRBranchedContext::new();
+        let mut curr_ctx = HIRBranchedContext::new(None); // TODO: remove type reference
         let body = lower_ast_body(context, &mut curr_ctx, body, true)?;
 
         let ind = container

--- a/compiler/astoir_hir_lowering/src/values.rs
+++ b/compiler/astoir_hir_lowering/src/values.rs
@@ -218,7 +218,7 @@ pub fn lower_ast_value(
             return lower_ast_variable_reference(context, curr_ctx, node, true);
         }
 
-        ASTTreeNodeKind::PointerGrab(_) => return lower_ast_pointer(context, curr_ctx, node),
+        ASTTreeNodeKind::Dereference(_) => return lower_ast_pointer(context, curr_ctx, node),
 
         ASTTreeNodeKind::ReferenceGrab(_) => return lower_ast_reference(context, curr_ctx, node),
 
@@ -296,10 +296,12 @@ pub fn lower_ast_pointer(
     curr_ctx: &mut HIRBranchedContext,
     node: Box<ASTTreeNode>,
 ) -> DiagnosticResult<Box<HIRNode>> {
-    if let ASTTreeNodeKind::PointerGrab(val) = node.kind.clone() {
+    if let ASTTreeNodeKind::Dereference(val) = node.kind.clone() {
         let val = lower_ast_value(context, curr_ctx, val)?;
 
-        if !val.is_variable_representative() {
+        let ty = val.get_node_type(context, curr_ctx);
+
+        if ty.is_none() || !ty.unwrap().is_pointer() {
             return Err(make_invalid_pointing(&*node).into());
         }
 
@@ -308,7 +310,7 @@ pub fn lower_ast_pointer(
         curr_ctx.introduce_variable_refer(r.0);
 
         return Ok(Box::new(HIRNode::new(
-            HIRNodeKind::PointerGrab { val },
+            HIRNodeKind::Dereference { val },
             &node.start,
             &node.end,
         )));

--- a/compiler/astoir_hir_lowering/src/values.rs
+++ b/compiler/astoir_hir_lowering/src/values.rs
@@ -1,8 +1,11 @@
-use ast::tree::{ASTTreeNode, ASTTreeNodeKind};
+use ast::{
+    ranges::ASTRange,
+    tree::{ASTTreeNode, ASTTreeNodeKind},
+};
 use astoir_hir::{
     ctx::{HIRBranchedContext, HIRContext, get_variable},
     nodes::{HIRNode, HIRNodeKind},
-    structs::StructLRUStep,
+    structs::{HIRRange, StructLRUStep},
 };
 use compiler_global_scope::key::EntryKey;
 use compiler_typing::tree::Type;
@@ -229,6 +232,17 @@ pub fn lower_ast_value(
 
         _ => panic!("Invalid AST value node"),
     }
+}
+
+pub fn lower_ast_range(
+    context: &mut HIRContext,
+    curr_ctx: &mut HIRBranchedContext,
+    range: ASTRange,
+) -> DiagnosticResult<HIRRange> {
+    let min = lower_ast_value(context, curr_ctx, range.min.clone())?;
+    let max = lower_ast_value(context, curr_ctx, range.max)?;
+
+    Ok(HIRRange { min, max })
 }
 
 pub fn lower_ast_array_init(

--- a/compiler/astoir_hir_lowering/src/values.rs
+++ b/compiler/astoir_hir_lowering/src/values.rs
@@ -10,7 +10,7 @@ use astoir_hir::{
 use compiler_global_scope::key::EntryKey;
 use compiler_typing::tree::Type;
 use diagnostics::{
-    DiagnosticResult,
+    DiagnosticResult, DiagnosticSpanOrigin,
     builders::{make_invalid_pointing, make_struct_missing_field, make_struct_missing_func},
 };
 
@@ -234,13 +234,26 @@ pub fn lower_ast_value(
     }
 }
 
-pub fn lower_ast_range(
+pub fn lower_ast_range<K: DiagnosticSpanOrigin>(
     context: &mut HIRContext,
     curr_ctx: &mut HIRBranchedContext,
     range: ASTRange,
+    ty: Type,
+    origin: &K,
 ) -> DiagnosticResult<HIRRange> {
-    let min = lower_ast_value(context, curr_ctx, range.min.clone())?;
-    let max = lower_ast_value(context, curr_ctx, range.max)?;
+    let min = Box::new(
+        lower_ast_value(context, curr_ctx, range.min.clone())?.use_as(
+            context,
+            curr_ctx,
+            ty.clone(),
+            origin,
+            None,
+        )?,
+    );
+    let max = Box::new(
+        lower_ast_value(context, curr_ctx, range.max)?
+            .use_as(context, curr_ctx, ty, origin, None)?,
+    );
 
     Ok(HIRRange { min, max })
 }

--- a/compiler/astoir_hir_lowering/src/values.rs
+++ b/compiler/astoir_hir_lowering/src/values.rs
@@ -345,11 +345,22 @@ pub fn lower_ast_pointer_modify(
             .get_inner_type()
             .can_transmute(&val_type, &context.global_scope.scope)
         {
-            return Err(make_expected_simple_error(&*val, &ty.unwrap(), &val_type).into());
+            return Err(make_expected_simple_error(&*val, &ty.clone().unwrap(), &val_type).into());
         }
 
+        let val = val.use_as(
+            context,
+            curr_ctx,
+            *ty.clone().unwrap().get_inner_type(),
+            &*val,
+            None,
+        )?;
+
         return Ok(Box::new(HIRNode::new(
-            HIRNodeKind::DereferenceModify { pointer: ptr, val },
+            HIRNodeKind::DereferenceModify {
+                pointer: ptr,
+                val: Box::new(val),
+            },
             &node.start,
             &node.end,
         )));

--- a/compiler/astoir_hir_lowering/src/values.rs
+++ b/compiler/astoir_hir_lowering/src/values.rs
@@ -11,7 +11,10 @@ use compiler_global_scope::key::EntryKey;
 use compiler_typing::tree::Type;
 use diagnostics::{
     DiagnosticResult, DiagnosticSpanOrigin,
-    builders::{make_invalid_pointing, make_struct_missing_field, make_struct_missing_func},
+    builders::{
+        make_expected_simple_error, make_invalid_pointing, make_struct_missing_field,
+        make_struct_missing_func,
+    },
 };
 
 use crate::{
@@ -219,7 +222,6 @@ pub fn lower_ast_value(
         }
 
         ASTTreeNodeKind::Dereference(_) => return lower_ast_pointer(context, curr_ctx, node),
-
         ASTTreeNodeKind::ReferenceGrab(_) => return lower_ast_reference(context, curr_ctx, node),
 
         ASTTreeNodeKind::UnwrapCondition { .. } => {
@@ -305,12 +307,49 @@ pub fn lower_ast_pointer(
             return Err(make_invalid_pointing(&*node).into());
         }
 
-        let r = val.get_variable_represent();
+        // TODO: add deref counter perhaps?
 
-        curr_ctx.introduce_variable_refer(r.0);
+        //let r = val.get_variable_represent();
+
+        //curr_ctx.introduce_variable_refer(r.0);
 
         return Ok(Box::new(HIRNode::new(
             HIRNodeKind::Dereference { val },
+            &node.start,
+            &node.end,
+        )));
+    }
+
+    panic!("Invalid node")
+}
+
+pub fn lower_ast_pointer_modify(
+    context: &mut HIRContext,
+    curr_ctx: &mut HIRBranchedContext,
+    node: Box<ASTTreeNode>,
+) -> DiagnosticResult<Box<HIRNode>> {
+    if let ASTTreeNodeKind::DereferenceModify { pointer, val } = node.kind.clone() {
+        let ptr = lower_ast_value(context, curr_ctx, pointer)?;
+        let ty = ptr.get_node_type(context, curr_ctx);
+
+        let val = lower_ast_value(context, curr_ctx, val)?;
+        let val_type = val.get_node_type(context, curr_ctx).unwrap();
+
+        if ty.is_none() || !ty.clone().unwrap().is_pointer() {
+            return Err(make_invalid_pointing(&*node).into());
+        }
+
+        if !ty
+            .clone()
+            .unwrap()
+            .get_inner_type()
+            .can_transmute(&val_type, &context.global_scope.scope)
+        {
+            return Err(make_expected_simple_error(&*val, &ty.unwrap(), &val_type).into());
+        }
+
+        return Ok(Box::new(HIRNode::new(
+            HIRNodeKind::DereferenceModify { pointer: ptr, val },
             &node.start,
             &node.end,
         )));

--- a/compiler/astoir_hir_lowering/src/values.rs
+++ b/compiler/astoir_hir_lowering/src/values.rs
@@ -319,6 +319,8 @@ pub fn lower_ast_pointer(
     panic!("Invalid node")
 }
 
+//pub fn lower_ast_pointer_modify()
+
 pub fn lower_ast_reference(
     context: &mut HIRContext,
     curr_ctx: &mut HIRBranchedContext,

--- a/compiler/astoir_hir_lowering/src/var.rs
+++ b/compiler/astoir_hir_lowering/src/var.rs
@@ -40,8 +40,6 @@ pub fn lower_ast_variable_declaration(
             }
         }
 
-        println!("Variable introduce: {} -> {}", var_name.hash, var_name.val);
-
         let name_ind = curr_ctx.introduce_variable(
             var_name.hash,
             lowered.clone(),

--- a/compiler/astoir_hir_lowering/src/var.rs
+++ b/compiler/astoir_hir_lowering/src/var.rs
@@ -1,5 +1,4 @@
 use ast::tree::{ASTTreeNode, ASTTreeNodeKind};
-use ast_parser::structs::val;
 use astoir_hir::{
     ctx::{HIRBranchedContext, HIRContext, VariableKind, get_variable},
     nodes::{HIRNode, HIRNodeKind},

--- a/compiler/astoir_hir_lowering/src/var.rs
+++ b/compiler/astoir_hir_lowering/src/var.rs
@@ -1,4 +1,5 @@
 use ast::tree::{ASTTreeNode, ASTTreeNodeKind};
+use ast_parser::structs::val;
 use astoir_hir::{
     ctx::{HIRBranchedContext, HIRContext, VariableKind, get_variable},
     nodes::{HIRNode, HIRNodeKind},
@@ -12,6 +13,7 @@ pub fn lower_ast_variable_declaration(
     context: &mut HIRContext,
     curr_ctx: &mut HIRBranchedContext,
     node: Box<ASTTreeNode>,
+    force_default: bool,
 ) -> DiagnosticResult<Box<HIRNode>> {
     if let ASTTreeNodeKind::VarDeclaration {
         var_name,
@@ -28,8 +30,11 @@ pub fn lower_ast_variable_declaration(
 
         let lowered = lower_ast_type(context, var_type, &*node)?;
 
-        let name_ind =
-            curr_ctx.introduce_variable(var_name.hash, lowered.clone(), value.is_some())?;
+        let name_ind = curr_ctx.introduce_variable(
+            var_name.hash,
+            lowered.clone(),
+            value.is_some() || force_default,
+        )?;
 
         let default_val;
 

--- a/compiler/astoir_hir_lowering/src/var.rs
+++ b/compiler/astoir_hir_lowering/src/var.rs
@@ -4,7 +4,11 @@ use astoir_hir::{
     nodes::{HIRNode, HIRNodeKind},
 };
 use compiler_global_scope::key::EntryKey;
-use diagnostics::{DiagnosticResult, builders::make_variable_uninit};
+use compiler_typing::tree::Type;
+use diagnostics::{
+    DiagnosticResult,
+    builders::{make_expected_simple_error, make_variable_uninit},
+};
 
 use crate::{arrays::lower_ast_array_index_access, types::lower_ast_type, values::lower_ast_value};
 
@@ -13,6 +17,7 @@ pub fn lower_ast_variable_declaration(
     curr_ctx: &mut HIRBranchedContext,
     node: Box<ASTTreeNode>,
     force_default: bool,
+    enforce_type: Option<Type>,
 ) -> DiagnosticResult<Box<HIRNode>> {
     if let ASTTreeNodeKind::VarDeclaration {
         var_name,
@@ -28,6 +33,12 @@ pub fn lower_ast_variable_declaration(
         )?;
 
         let lowered = lower_ast_type(context, var_type, &*node)?;
+
+        if let Some(enforce_type) = enforce_type {
+            if lowered != enforce_type {
+                return Err(make_expected_simple_error(&*node, &enforce_type, &lowered).into());
+            }
+        }
 
         let name_ind = curr_ctx.introduce_variable(
             var_name.hash,

--- a/compiler/astoir_hir_lowering/src/var.rs
+++ b/compiler/astoir_hir_lowering/src/var.rs
@@ -40,6 +40,8 @@ pub fn lower_ast_variable_declaration(
             }
         }
 
+        println!("Variable introduce: {} -> {}", var_name.hash, var_name.val);
+
         let name_ind = curr_ctx.introduce_variable(
             var_name.hash,
             lowered.clone(),

--- a/compiler/astoir_mir/src/blocks/mod.rs
+++ b/compiler/astoir_mir/src/blocks/mod.rs
@@ -109,6 +109,19 @@ impl MIRBlock {
         return ind;
     }
 
+    pub fn propagate_variables(
+        base: MIRBlockReference,
+        target: MIRBlockReference,
+        ctx: &mut MIRContext,
+    ) {
+        let variables = ctx.blocks[base].variables.clone();
+        let target_block = &mut ctx.blocks[target];
+
+        for (ind, hint) in variables {
+            target_block.variables.insert(ind, hint);
+        }
+    }
+
     pub fn get_variable_ref(&self, var_ind: usize) -> DiagnosticResult<MIRVariableReference> {
         let var = &self.variables[&var_ind];
 

--- a/compiler/astoir_mir/src/blocks/mod.rs
+++ b/compiler/astoir_mir/src/blocks/mod.rs
@@ -1,11 +1,13 @@
-use std::{collections::HashMap, fmt::Display};
+use std::collections::HashMap;
 
 use diagnostics::{DiagnosticResult, unsure_panic};
 
 use crate::{
+    DisplayAstoIR,
     blocks::refer::MIRBlockReference,
     builder::build_phi,
     ctx::MIRContext,
+    fmt::DisplayWithCtx,
     inst_writer::BlockPosition,
     insts::MIRInstruction,
     vals::{base::BaseMIRValue, refer::MIRVariableReference},
@@ -196,8 +198,8 @@ impl MIRBlock {
     }
 }
 
-impl Display for MIRBlock {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl DisplayAstoIR for MIRBlock {
+    fn format(&self, f: &mut std::fmt::Formatter<'_>, ctx: &MIRContext) -> std::fmt::Result {
         writeln!(f, "%block_{}", self.self_ref)?;
 
         if !self.merge_blocks.is_empty() {
@@ -209,18 +211,24 @@ impl Display for MIRBlock {
         }
 
         for inst in &self.instructions {
-            write!(f, "	{}", inst)?;
+            write!(f, "	{}", DisplayWithCtx::new(ctx, inst))?;
         }
 
         Ok(())
     }
 }
 
-impl Display for MIRBlockHeldInstruction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl DisplayAstoIR for MIRBlockHeldInstruction {
+    fn format(&self, f: &mut std::fmt::Formatter<'_>, ctx: &MIRContext) -> std::fmt::Result {
         match self {
-            Self::Valued(a, b) => write!(f, "#{} = {}", *b, a),
-            Self::Valueless(a) => write!(f, "{}", a),
+            Self::Valued(a, b) => writeln!(
+                f,
+                "({}) #{} = {}",
+                a.get_return_type(ctx),
+                b,
+                DisplayWithCtx::new(ctx, a)
+            ),
+            Self::Valueless(a) => writeln!(f, "(void) {}", DisplayWithCtx::new(ctx, a)),
         }
     }
 }

--- a/compiler/astoir_mir/src/builder.rs
+++ b/compiler/astoir_mir/src/builder.rs
@@ -60,7 +60,8 @@ pub fn build_store(
             return build_store_fallback(ctx, ptr, val.clone(), storage);
         }
 
-        unsure_panic!("cannot put this value onto this pointer since it's not the type");
+        println!("Expected {}({}) got {}({})", hint, base, val.vtype, val);
+        //unsure_panic!("cannot put this value onto this pointer since it's not the type.");
     }
 
     ctx.append_inst(MIRInstruction::Store {
@@ -69,6 +70,17 @@ pub fn build_store(
     });
 
     return Ok(());
+}
+
+pub fn build_pointer_deref(
+    ctx: &mut MIRContext,
+    val: MIRPointerValue,
+) -> DiagnosticResult<BaseMIRValue> {
+    let res = ctx
+        .append_inst(MIRInstruction::DerefPointer { ptr: val })
+        .get()?;
+
+    Ok(res)
 }
 
 pub fn build_downcast_int(

--- a/compiler/astoir_mir/src/builder.rs
+++ b/compiler/astoir_mir/src/builder.rs
@@ -35,7 +35,9 @@ pub fn build_stack_alloc(
 }
 
 pub fn build_load(ctx: &mut MIRContext, ptr: MIRPointerValue) -> DiagnosticResult<BaseMIRValue> {
-    let res = ctx.append_inst(MIRInstruction::Load { value: ptr }).get()?;
+    let res = ctx
+        .append_inst(MIRInstruction::Load { value: ptr.clone() })
+        .get()?;
 
     return Ok(res);
 }
@@ -60,8 +62,8 @@ pub fn build_store(
             return build_store_fallback(ctx, ptr, val.clone(), storage);
         }
 
-        println!("Expected {}({}) got {}({})", hint, base, val.vtype, val);
-        //unsure_panic!("cannot put this value onto this pointer since it's not the type.");
+        //println!("Expected {}({}) got {}({})", hint, base, val.vtype, val);
+        unsure_panic!("cannot put this value onto this pointer since it's not the type.");
     }
 
     ctx.append_inst(MIRInstruction::Store {

--- a/compiler/astoir_mir/src/ctx.rs
+++ b/compiler/astoir_mir/src/ctx.rs
@@ -1,14 +1,16 @@
-use std::{collections::HashMap, fmt::Display};
+use std::collections::HashMap;
 
 use diagnostics::DiagnosticResult;
 
 use crate::{
+    DisplayAstoIR,
     blocks::{
         MIRBlock, MIRBlockHeldInstruction,
         hints::{HintStorage, MIRValueHint},
         refer::MIRBlockReference,
     },
     builder::build_phi,
+    fmt::DisplayWithCtx,
     funcs::MIRFunction,
     inst_writer::{BlockPosition, InstructionWriterPosition},
     insts::{MIRInstruction, val::InstructionValue},
@@ -152,14 +154,14 @@ impl MIRContext {
     }
 }
 
-impl Display for MIRContext {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl DisplayAstoIR for MIRContext {
+    fn format(&self, f: &mut std::fmt::Formatter<'_>, ctx: &MIRContext) -> std::fmt::Result {
         for func in &self.functions {
             writeln!(f, "{}", func.1)?;
         }
 
         for block in &self.blocks {
-            writeln!(f, "{}", block)?;
+            writeln!(f, "{}", DisplayWithCtx::new(ctx, block))?;
         }
 
         Ok(())

--- a/compiler/astoir_mir/src/fmt.rs
+++ b/compiler/astoir_mir/src/fmt.rs
@@ -1,0 +1,20 @@
+use std::fmt::Display;
+
+use crate::{DisplayAstoIR, ctx::MIRContext};
+
+pub struct DisplayWithCtx<'a, K: DisplayAstoIR> {
+    value: &'a K,
+    ctx: &'a MIRContext,
+}
+
+impl<'a, K: DisplayAstoIR> DisplayWithCtx<'a, K> {
+    pub fn new(ctx: &'a MIRContext, value: &'a K) -> Self {
+        Self { value, ctx }
+    }
+}
+
+impl<'a, K: DisplayAstoIR> Display for DisplayWithCtx<'a, K> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.value.format(f, self.ctx)
+    }
+}

--- a/compiler/astoir_mir/src/insts/mod.rs
+++ b/compiler/astoir_mir/src/insts/mod.rs
@@ -1,12 +1,12 @@
 //! The definitions for instructions within the MIR.
 
-use std::fmt::Display;
-
 use compiler_typing::{raw::RawType, tree::Type};
 
 use crate::{
+    DisplayAstoIR,
     blocks::refer::MIRBlockReference,
     ctx::MIRContext,
+    fmt::DisplayWithCtx,
     vals::{base::BaseMIRValue, float::MIRFloatValue, int::MIRIntValue, ptr::MIRPointerValue},
 };
 
@@ -504,14 +504,14 @@ impl MIRInstruction {
 
             _ => panic!(
                 "Tried using get_return_type on non returning type! {}",
-                self
+                DisplayWithCtx::new(ctx, self)
             ),
         }
     }
 }
 
-impl Display for MIRInstruction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl DisplayAstoIR for MIRInstruction {
+    fn format(&self, f: &mut std::fmt::Formatter<'_>, _ctx: &MIRContext) -> std::fmt::Result {
         match self {
             Self::StackAlloc { alloc_size, t: _ } => writeln!(f, "stkalloc {}", *alloc_size)?,
             Self::Load { value } => writeln!(f, "load {}", value)?,

--- a/compiler/astoir_mir/src/insts/mod.rs
+++ b/compiler/astoir_mir/src/insts/mod.rs
@@ -320,7 +320,9 @@ impl MIRInstruction {
 
     pub fn get_return_type(&self, ctx: &MIRContext) -> Type {
         match self {
-            Self::StackAlloc { .. } => return Type::GenericLowered(RawType::Pointer),
+            Self::StackAlloc { alloc_size: _, t } => {
+                return Type::Pointer(false, Box::new(t.clone()));
+            }
             Self::Load { value } => {
                 let base: BaseMIRValue = value.clone().into();
 

--- a/compiler/astoir_mir/src/insts/mod.rs
+++ b/compiler/astoir_mir/src/insts/mod.rs
@@ -326,7 +326,7 @@ impl MIRInstruction {
 
                 let hint = ctx.ssa_hints.get_hint(base.get_ssa_index());
 
-                return hint.as_pointer();
+                return hint.get_type();
             }
 
             Self::DerefPointer { ptr } => {

--- a/compiler/astoir_mir/src/insts/mod.rs
+++ b/compiler/astoir_mir/src/insts/mod.rs
@@ -22,6 +22,11 @@ pub enum MIRInstruction {
     Load {
         value: MIRPointerValue,
     },
+
+    DerefPointer {
+        ptr: MIRPointerValue,
+    },
+
     Store {
         variable: MIRPointerValue,
         value: BaseMIRValue,
@@ -324,6 +329,12 @@ impl MIRInstruction {
                 return hint.as_pointer();
             }
 
+            Self::DerefPointer { ptr } => {
+                let base: BaseMIRValue = ptr.clone().into();
+
+                *base.vtype.get_inner_type()
+            }
+
             Self::DowncastInteger { val, size } => {
                 return Type::GenericLowered(RawType::Integer(*size, val.signed));
             }
@@ -505,6 +516,7 @@ impl Display for MIRInstruction {
             Self::StackAlloc { alloc_size, t: _ } => writeln!(f, "stkalloc {}", *alloc_size)?,
             Self::Load { value } => writeln!(f, "load {}", value)?,
             Self::Store { variable, value } => writeln!(f, "store d{} s{}", variable, value)?,
+            Self::DerefPointer { ptr } => writeln!(f, "ptrderef {}", ptr)?,
 
             Self::MemoryCopy { src, dest, sz } => {
                 writeln!(f, "unsmemcopy s{} d{} {}b", src, dest, sz)?

--- a/compiler/astoir_mir/src/lib.rs
+++ b/compiler/astoir_mir/src/lib.rs
@@ -1,10 +1,17 @@
 //! The MIR layer of the AstoIR.
 //! The MIR layer represents a block based representation of the program. Uses low level instructions near Assembly
 //!
+
+use crate::ctx::MIRContext;
 pub mod blocks;
 pub mod builder;
 pub mod ctx;
+pub mod fmt;
 pub mod funcs;
 pub mod inst_writer;
 pub mod insts;
 pub mod vals;
+
+pub trait DisplayAstoIR {
+    fn format(&self, f: &mut std::fmt::Formatter<'_>, ctx: &MIRContext) -> std::fmt::Result;
+}

--- a/compiler/astoir_mir/src/vals/arrays.rs
+++ b/compiler/astoir_mir/src/vals/arrays.rs
@@ -28,8 +28,6 @@ impl Into<BaseMIRValue> for MIRArrayValue {
 
 impl Display for MIRArrayValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "#{}", self.base.get_ssa_index())?;
-
-        Ok(())
+        self.base.fmt(f)
     }
 }

--- a/compiler/astoir_mir/src/vals/base.rs
+++ b/compiler/astoir_mir/src/vals/base.rs
@@ -59,7 +59,7 @@ impl PartialEq for BaseMIRValue {
 
 impl Display for BaseMIRValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "#{}", self.val_index)?;
+        write!(f, "#{} ({})", self.val_index, self.vtype)?;
 
         Ok(())
     }

--- a/compiler/astoir_mir/src/vals/float.rs
+++ b/compiler/astoir_mir/src/vals/float.rs
@@ -34,8 +34,6 @@ impl Into<BaseMIRValue> for MIRFloatValue {
 
 impl Display for MIRFloatValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "#{}", self.base.get_ssa_index())?;
-
-        Ok(())
+        self.base.fmt(f)
     }
 }

--- a/compiler/astoir_mir/src/vals/int.rs
+++ b/compiler/astoir_mir/src/vals/int.rs
@@ -42,8 +42,6 @@ impl Into<BaseMIRValue> for MIRIntValue {
 
 impl Display for MIRIntValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "#{}", self.base.get_ssa_index())?;
-
-        Ok(())
+        self.base.fmt(f)
     }
 }

--- a/compiler/astoir_mir/src/vals/ptr.rs
+++ b/compiler/astoir_mir/src/vals/ptr.rs
@@ -31,8 +31,6 @@ impl Into<BaseMIRValue> for MIRPointerValue {
 
 impl Display for MIRPointerValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "#{}", self.base.get_ssa_index())?;
-
-        Ok(())
+        self.base.fmt(f)
     }
 }

--- a/compiler/astoir_mir/src/vals/refer.rs
+++ b/compiler/astoir_mir/src/vals/refer.rs
@@ -59,14 +59,16 @@ impl MIRVariableReference {
         storage: &TypedGlobalScope,
     ) -> DiagnosticResult<bool> {
         if self.is_pointer_ref() {
-            let mut ptr_ref = self.as_pointer_ref()?;
-            let hint = ctx
-                .ssa_hints
-                .get_hint(BaseMIRValue::from(ptr_ref.clone().into()).get_ssa_index());
+            let ptr_ref = self.as_pointer_ref()?;
 
-            if hint.get_type().is_technically_pointer() {
-                ptr_ref = build_load(ctx, ptr_ref)?.as_ptr()?;
-            }
+            //let _hint = ctx
+            //    .ssa_hints
+            //    .get_hint(BaseMIRValue::from(ptr_ref.clone().into()).get_ssa_index());
+
+            //if hint.get_type().is_technically_pointer() {
+            //    ptr_ref = build_load(ctx, ptr_ref)?.as_ptr()?;
+            //    println!("Triggered {}", val);
+            //}
 
             build_store(ctx, storage, ptr_ref, val)?;
 

--- a/compiler/astoir_mir/src/vals/structs.rs
+++ b/compiler/astoir_mir/src/vals/structs.rs
@@ -31,8 +31,6 @@ impl Into<BaseMIRValue> for MIRStructValue {
 
 impl Display for MIRStructValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "#{}", self.base.get_ssa_index())?;
-
-        Ok(())
+        self.base.fmt(f)
     }
 }

--- a/compiler/astoir_mir_lowering/src/body.rs
+++ b/compiler/astoir_mir_lowering/src/body.rs
@@ -8,7 +8,10 @@ use diagnostics::{
 use crate::{
     MIRLoweringContext,
     arrays::lower_hir_array_modify,
-    control::{forloop::lower_hir_for_loop, ifstatement::lower_hir_if_statement},
+    control::{
+        forloop::{lower_hir_for_loop, lower_hir_ranged_for_loop},
+        ifstatement::lower_hir_if_statement,
+    },
     funcs::lower_hir_function_call,
     introductions::handle_var_introduction_queue,
     math::lower_hir_math_operation,
@@ -30,7 +33,10 @@ pub fn lower_hir_body_member(
 
     return match node.kind.clone() {
         HIRNodeKind::VarAssigment { .. } => lower_hir_variable_assignment(block, node, ctx),
-        HIRNodeKind::VarDeclaration { .. } => lower_hir_variable_declaration(block, node, ctx),
+        HIRNodeKind::VarDeclaration { .. } => {
+            let _ = lower_hir_variable_declaration(block, node, ctx, None)?;
+            Ok(true)
+        }
         HIRNodeKind::MathOperation {
             left: _,
             right: _,
@@ -46,6 +52,12 @@ pub fn lower_hir_body_member(
         }
 
         HIRNodeKind::ArrayIndexModify { .. } => lower_hir_array_modify(block, node, ctx),
+
+        HIRNodeKind::RangedForBlock { .. } => {
+            let _ = lower_hir_ranged_for_loop(block, node, ctx)?;
+
+            Ok(true)
+        }
 
         HIRNodeKind::ForBlock { .. } => lower_hir_for_loop(block, node, ctx),
         HIRNodeKind::IfStatement { .. } => lower_hir_if_statement(block, node, ctx),

--- a/compiler/astoir_mir_lowering/src/body.rs
+++ b/compiler/astoir_mir_lowering/src/body.rs
@@ -16,7 +16,7 @@ use crate::{
     introductions::handle_var_introduction_queue,
     math::lower_hir_math_operation,
     values::lower_hir_value,
-    vars::{lower_hir_variable_assignment, lower_hir_variable_declaration},
+    vars::{lower_hir_deref_modify, lower_hir_variable_assignment, lower_hir_variable_declaration},
 };
 
 pub fn lower_hir_body_member(
@@ -78,6 +78,12 @@ pub fn lower_hir_body_member(
 
             ctx.mir_ctx
                 .append_inst(MIRInstruction::Return { val: None });
+
+            return Ok(true);
+        }
+
+        HIRNodeKind::DereferenceModify { .. } => {
+            let _ = lower_hir_deref_modify(block, node, ctx)?;
 
             return Ok(true);
         }

--- a/compiler/astoir_mir_lowering/src/casts.rs
+++ b/compiler/astoir_mir_lowering/src/casts.rs
@@ -3,6 +3,7 @@ use astoir_mir::{
     blocks::{hints::MIRValueHint, refer::MIRBlockReference},
     vals::base::BaseMIRValue,
 };
+use compiler_typing::raw::RawType;
 use diagnostics::DiagnosticResult;
 
 use crate::{MIRLoweringContext, lower_hir_type, values::lower_hir_value};
@@ -39,7 +40,26 @@ pub fn lower_cast(
             return Ok(value);
         }
 
-        panic!("Bad castt {:#?} -> {:#?}", old_type, new_type);
+        if old_type.is_generic_direct()
+            && new_type.is_generic_direct()
+            && old_type.as_generic() == RawType::StaticString
+            && new_type.as_generic() == RawType::Pointer
+        {
+            match ctx.mir_ctx.ssa_hints.vec[value.get_ssa_index()] {
+                MIRValueHint::Pointer(_) => {
+                    ctx.mir_ctx.ssa_hints.vec[value.get_ssa_index()] =
+                        MIRValueHint::Pointer(new_type)
+                }
+                MIRValueHint::Value(_) => {
+                    ctx.mir_ctx.ssa_hints.vec[value.get_ssa_index()] = MIRValueHint::Value(new_type)
+                }
+                _ => panic!("constant enum cast"),
+            }
+
+            return Ok(value);
+        }
+
+        panic!("Bad cast {:#?} -> {:#?}", old_type, new_type);
     }
 
     panic!("Invalid node or cast!")

--- a/compiler/astoir_mir_lowering/src/control/forloop.rs
+++ b/compiler/astoir_mir_lowering/src/control/forloop.rs
@@ -42,6 +42,10 @@ pub fn lower_hir_for_loop(
         move_current_diagnostic_pos(initial_state.get_pos());
         lower_hir_variable_declaration(block, initial_state, ctx, None)?;
 
+        MIRBlock::propagate_variables(block, body_ref, &mut ctx.mir_ctx);
+        MIRBlock::propagate_variables(block, header_ref, &mut ctx.mir_ctx);
+        MIRBlock::propagate_variables(block, cond_ref, &mut ctx.mir_ctx);
+
         build_unconditional_branch(&mut ctx.mir_ctx, cond_ref)?;
 
         // Body reference
@@ -90,15 +94,15 @@ pub fn lower_hir_ranged_for_loop(
         body,
     } = node.kind.clone()
     {
+        move_current_diagnostic_pos(node.get_pos());
+
         let header_ref = MIRBlock::new_merge(block, &mut ctx.mir_ctx, false);
         let cond_ref = MIRBlock::new_merge(header_ref, &mut ctx.mir_ctx, false);
-        let body_ref = MIRBlock::new_merge(header_ref, &mut ctx.mir_ctx, false);
         let exit_ref = MIRBlock::new_merge(block, &mut ctx.mir_ctx, false);
+        let body_ref = MIRBlock::new_merge(header_ref, &mut ctx.mir_ctx, false);
 
         ctx.mir_ctx.blocks[header_ref].merge_blocks.push(block);
         ctx.mir_ctx.blocks[header_ref].merge_blocks.push(body_ref);
-
-        move_current_diagnostic_pos(node.get_pos());
 
         // Initial state
 
@@ -106,6 +110,10 @@ pub fn lower_hir_ranged_for_loop(
         let max = lower_hir_value(block, range.max, ctx)?;
 
         let v = lower_hir_variable_declaration(block, variable, ctx, Some(min.clone()))?;
+
+        MIRBlock::propagate_variables(block, body_ref, &mut ctx.mir_ctx);
+        MIRBlock::propagate_variables(block, header_ref, &mut ctx.mir_ctx);
+        MIRBlock::propagate_variables(block, cond_ref, &mut ctx.mir_ctx);
 
         build_unconditional_branch(&mut ctx.mir_ctx, cond_ref)?;
 

--- a/compiler/astoir_mir_lowering/src/control/forloop.rs
+++ b/compiler/astoir_mir_lowering/src/control/forloop.rs
@@ -3,9 +3,14 @@
 use astoir_hir::nodes::{HIRNode, HIRNodeKind};
 use astoir_mir::{
     blocks::{MIRBlock, refer::MIRBlockReference},
-    builder::{build_conditional_branch, build_unconditional_branch},
+    builder::{
+        build_comp_lt, build_conditional_branch, build_int_add, build_unconditional_branch,
+        build_unsigned_int_const,
+    },
 };
-use diagnostics::{DiagnosticResult, DiagnosticSpanOrigin, move_current_diagnostic_pos};
+use diagnostics::{
+    DiagnosticResult, DiagnosticSpanOrigin, MaybeDiagnostic, move_current_diagnostic_pos,
+};
 
 use crate::{
     MIRLoweringContext, body::lower_hir_body, math::lower_hir_math_operation,
@@ -32,22 +37,32 @@ pub fn lower_hir_for_loop(
         ctx.mir_ctx.blocks[header_ref].merge_blocks.push(block);
         ctx.mir_ctx.blocks[header_ref].merge_blocks.push(body_ref);
 
+        // Initial State
+
         move_current_diagnostic_pos(initial_state.get_pos());
-        lower_hir_variable_declaration(block, initial_state, ctx)?;
+        lower_hir_variable_declaration(block, initial_state, ctx, None)?;
+
+        // Body reference
 
         ctx.mir_ctx.writer.move_end(body_ref);
 
         lower_hir_body(body_ref, body, ctx)?;
+
+        // Incrementation
 
         move_current_diagnostic_pos(incrementation.get_pos());
         lower_hir_math_operation(body_ref, incrementation, ctx)?;
 
         build_unconditional_branch(&mut ctx.mir_ctx, header_ref)?;
 
+        // Header
+
         ctx.mir_ctx.writer.move_end(header_ref);
 
         ctx.mir_ctx.resolve_ssa(header_ref)?;
         build_unconditional_branch(&mut ctx.mir_ctx, cond_ref)?;
+
+        // Condition
 
         ctx.mir_ctx.writer.move_end(cond_ref);
 
@@ -55,6 +70,76 @@ pub fn lower_hir_for_loop(
         let cond_val = lower_hir_value(block, condition, ctx)?;
 
         build_conditional_branch(&mut ctx.mir_ctx, cond_val.as_int()?, body_ref, exit_ref)?;
+
+        ctx.mir_ctx.writer.move_end(exit_ref);
+    }
+
+    panic!("Invalid node")
+}
+
+pub fn lower_hir_ranged_for_loop(
+    block: MIRBlockReference,
+    node: Box<HIRNode>,
+    ctx: &mut MIRLoweringContext,
+) -> MaybeDiagnostic {
+    if let HIRNodeKind::RangedForBlock {
+        variable,
+        range,
+        body,
+    } = node.kind.clone()
+    {
+        let header_ref = MIRBlock::new_merge(block, &mut ctx.mir_ctx, false);
+        let cond_ref = MIRBlock::new_merge(header_ref, &mut ctx.mir_ctx, false);
+        let body_ref = MIRBlock::new_merge(header_ref, &mut ctx.mir_ctx, false);
+        let exit_ref = MIRBlock::new_merge(block, &mut ctx.mir_ctx, false);
+
+        ctx.mir_ctx.blocks[header_ref].merge_blocks.push(block);
+        ctx.mir_ctx.blocks[header_ref].merge_blocks.push(body_ref);
+
+        move_current_diagnostic_pos(node.get_pos());
+
+        // Initial state
+
+        let min = lower_hir_value(block, range.min, ctx)?;
+        let max = lower_hir_value(block, range.max, ctx)?;
+
+        let v = lower_hir_variable_declaration(block, variable, ctx, Some(min.clone()))?;
+
+        // Body reference
+
+        ctx.mir_ctx.writer.move_end(body_ref);
+        lower_hir_body(body_ref, body, ctx)?;
+
+        // Incrementation
+
+        let val = v.read(body_ref, &mut ctx.mir_ctx)?;
+        let increment = build_unsigned_int_const(&mut ctx.mir_ctx, 1, min.as_int()?.size)?;
+        let incremented = build_int_add(&mut ctx.mir_ctx, val.as_int()?, increment, false, false)?;
+
+        v.write(
+            body_ref,
+            &mut ctx.mir_ctx,
+            incremented.base,
+            &ctx.hir_ctx.global_scope.scope,
+        )?;
+
+        build_unconditional_branch(&mut ctx.mir_ctx, header_ref)?;
+
+        // Header
+
+        ctx.mir_ctx.writer.move_end(header_ref);
+        ctx.mir_ctx.resolve_ssa(header_ref)?;
+
+        build_unconditional_branch(&mut ctx.mir_ctx, cond_ref)?;
+
+        // Condition
+
+        ctx.mir_ctx.writer.move_end(cond_ref);
+
+        let val = v.read(cond_ref, &mut ctx.mir_ctx)?.as_int()?;
+        let cond_val = build_comp_lt(&mut ctx.mir_ctx, val, max.as_int()?)?;
+
+        build_conditional_branch(&mut ctx.mir_ctx, cond_val, body_ref, exit_ref)?;
 
         ctx.mir_ctx.writer.move_end(exit_ref);
     }

--- a/compiler/astoir_mir_lowering/src/control/forloop.rs
+++ b/compiler/astoir_mir_lowering/src/control/forloop.rs
@@ -42,6 +42,8 @@ pub fn lower_hir_for_loop(
         move_current_diagnostic_pos(initial_state.get_pos());
         lower_hir_variable_declaration(block, initial_state, ctx, None)?;
 
+        build_unconditional_branch(&mut ctx.mir_ctx, cond_ref)?;
+
         // Body reference
 
         ctx.mir_ctx.writer.move_end(body_ref);
@@ -104,6 +106,8 @@ pub fn lower_hir_ranged_for_loop(
         let max = lower_hir_value(block, range.max, ctx)?;
 
         let v = lower_hir_variable_declaration(block, variable, ctx, Some(min.clone()))?;
+
+        build_unconditional_branch(&mut ctx.mir_ctx, cond_ref)?;
 
         // Body reference
 

--- a/compiler/astoir_mir_lowering/src/control/forloop.rs
+++ b/compiler/astoir_mir_lowering/src/control/forloop.rs
@@ -142,6 +142,8 @@ pub fn lower_hir_ranged_for_loop(
         build_conditional_branch(&mut ctx.mir_ctx, cond_val, body_ref, exit_ref)?;
 
         ctx.mir_ctx.writer.move_end(exit_ref);
+
+        return Ok(());
     }
 
     panic!("Invalid node")

--- a/compiler/astoir_mir_lowering/src/control/forloop.rs
+++ b/compiler/astoir_mir_lowering/src/control/forloop.rs
@@ -78,6 +78,8 @@ pub fn lower_hir_for_loop(
         build_conditional_branch(&mut ctx.mir_ctx, cond_val.as_int()?, body_ref, exit_ref)?;
 
         ctx.mir_ctx.writer.move_end(exit_ref);
+
+        return Ok(true);
     }
 
     panic!("Invalid node")

--- a/compiler/astoir_mir_lowering/src/funcs.rs
+++ b/compiler/astoir_mir_lowering/src/funcs.rs
@@ -83,11 +83,11 @@ pub fn lower_hir_function_decl(
     panic!("Invalid node")
 }
 
-pub fn lower_hir_shadow_decl(
+pub fn lower_hir_extern_decl(
     node: Box<HIRNode>,
     ctx: &mut MIRLoweringContext,
 ) -> DiagnosticResult<bool> {
-    if let HIRNodeKind::ShadowFunctionDeclaration {
+    if let HIRNodeKind::ExternFunctionDeclaration {
         func_name,
         arguments,
         return_type,

--- a/compiler/astoir_mir_lowering/src/lib.rs
+++ b/compiler/astoir_mir_lowering/src/lib.rs
@@ -11,7 +11,7 @@ use compiler_typing::{
 use compiler_utils::utils::indexed::IndexStorage;
 use diagnostics::{DiagnosticResult, unsure_panic};
 
-use crate::funcs::{lower_hir_function_decl, lower_hir_shadow_decl};
+use crate::funcs::{lower_hir_extern_decl, lower_hir_function_decl};
 
 pub mod arrays;
 pub mod body;
@@ -37,7 +37,7 @@ pub fn lower_hir_top_level(
 ) -> DiagnosticResult<bool> {
     return match node.kind {
         HIRNodeKind::FunctionDeclaration { .. } => lower_hir_function_decl(node, ctx),
-        HIRNodeKind::ShadowFunctionDeclaration { .. } => lower_hir_shadow_decl(node, ctx),
+        HIRNodeKind::ExternFunctionDeclaration { .. } => lower_hir_extern_decl(node, ctx),
         HIRNodeKind::StructDeclaration { .. } => {
             // Since Struct declarations are already fulled lowered in HIR, we do need handling here!
 

--- a/compiler/astoir_mir_lowering/src/math.rs
+++ b/compiler/astoir_mir_lowering/src/math.rs
@@ -29,7 +29,7 @@ pub fn lower_hir_math_operation(
         operation,
     } = node.clone().kind
     {
-        if operation.assigns && !left.is_variable_reference() {
+        if !operation.assigns && !left.is_variable_reference() {
             return Err(make_math_operation_req_assign(&*node).into());
         }
 

--- a/compiler/astoir_mir_lowering/src/values/mod.rs
+++ b/compiler/astoir_mir_lowering/src/values/mod.rs
@@ -88,7 +88,6 @@ pub fn lower_hir_value(
 
             return Ok(res.unwrap());
         }
-
         _ => panic!("Invalid node {:#?}", node),
     }
 }

--- a/compiler/astoir_mir_lowering/src/values/mod.rs
+++ b/compiler/astoir_mir_lowering/src/values/mod.rs
@@ -1,8 +1,8 @@
 use astoir_hir::nodes::{HIRNode, HIRNodeKind};
 use astoir_mir::{
     blocks::refer::MIRBlockReference,
-    builder::{build_pointer_deref, build_static_array_const, build_static_array_one_const},
-    vals::base::BaseMIRValue,
+    builder::{build_static_array_const, build_static_array_one_const},
+    vals::{base::BaseMIRValue, refer::MIRVariableReference},
 };
 use diagnostics::{
     DiagnosticResult, DiagnosticSpanOrigin, move_current_diagnostic_pos, unsure_panic,
@@ -52,7 +52,10 @@ pub fn lower_hir_value(
                 .read(block, &mut ctx.mir_ctx)?
                 .as_ptr()?;
 
-            let val = build_pointer_deref(&mut ctx.mir_ctx, ptr)?;
+            let var = MIRVariableReference::PointerReference(ptr);
+            let val = var.read(block, &mut ctx.mir_ctx)?;
+
+            //let val = build_pointer_deref(&mut ctx.mir_ctx, ptr)?;
 
             Ok(val)
         }

--- a/compiler/astoir_mir_lowering/src/values/mod.rs
+++ b/compiler/astoir_mir_lowering/src/values/mod.rs
@@ -1,7 +1,7 @@
 use astoir_hir::nodes::{HIRNode, HIRNodeKind};
 use astoir_mir::{
     blocks::refer::MIRBlockReference,
-    builder::{build_static_array_const, build_static_array_one_const},
+    builder::{build_pointer_deref, build_static_array_const, build_static_array_one_const},
     vals::base::BaseMIRValue,
 };
 use diagnostics::{
@@ -47,10 +47,14 @@ pub fn lower_hir_value(
                 .as_pointer_ref()?
                 .into());
         }
-        HIRNodeKind::PointerGrab { val } => {
-            return Ok(lower_hir_variable_reference(block, &val, ctx)?
-                .as_pointer_ref()?
-                .into());
+        HIRNodeKind::Dereference { val } => {
+            let ptr = lower_hir_variable_reference(block, &val, ctx)?
+                .read(block, &mut ctx.mir_ctx)?
+                .as_ptr()?;
+
+            let val = build_pointer_deref(&mut ctx.mir_ctx, ptr)?;
+
+            Ok(val)
         }
         HIRNodeKind::BooleanCondition { .. } => {
             return Ok(lowering_hir_boolean_condition(block, node, ctx)?.into());

--- a/compiler/astoir_mir_lowering/src/vars.rs
+++ b/compiler/astoir_mir_lowering/src/vars.rs
@@ -7,7 +7,9 @@ use astoir_mir::{
     vals::{base::BaseMIRValue, refer::MIRVariableReference},
 };
 use compiler_typing::{SizedType, TypedGlobalScopeEntry};
-use diagnostics::{DiagnosticResult, builders::make_expected_simple_error_originless};
+use diagnostics::{
+    DiagnosticResult, MaybeDiagnostic, builders::make_expected_simple_error_originless,
+};
 
 use crate::{MIRLoweringContext, lower_hir_type, values::lower_hir_value};
 
@@ -127,7 +129,7 @@ pub fn lower_hir_variable_declaration(
 pub fn lower_hir_variable_reference(
     block: MIRBlockReference,
     node: &Box<HIRNode>,
-    ctx: &MIRLoweringContext,
+    ctx: &mut MIRLoweringContext,
 ) -> DiagnosticResult<MIRVariableReference> {
     if let HIRNodeKind::VariableReference {
         index,
@@ -136,6 +138,29 @@ pub fn lower_hir_variable_reference(
     {
         // TODO: add support for static variables
         return ctx.mir_ctx.blocks[block].get_variable_ref(*index);
+    }
+
+    panic!("Invalid node")
+}
+
+pub fn lower_hir_deref_modify(
+    block: MIRBlockReference,
+    node: Box<HIRNode>,
+    ctx: &mut MIRLoweringContext,
+) -> MaybeDiagnostic {
+    if let HIRNodeKind::DereferenceModify { pointer, val } = node.kind.clone() {
+        let ptr = lower_hir_value(block, pointer, ctx)?.as_ptr()?;
+        let val = lower_hir_value(block, val, ctx)?;
+
+        let var = MIRVariableReference::PointerReference(ptr);
+        var.write(
+            block,
+            &mut ctx.mir_ctx,
+            val,
+            &ctx.hir_ctx.global_scope.scope,
+        )?;
+
+        return Ok(());
     }
 
     panic!("Invalid node")

--- a/compiler/astoir_mir_lowering/src/vars.rs
+++ b/compiler/astoir_mir_lowering/src/vars.rs
@@ -15,7 +15,8 @@ pub fn lower_hir_variable_declaration(
     block_id: MIRBlockReference,
     node: Box<HIRNode>,
     ctx: &mut MIRLoweringContext,
-) -> DiagnosticResult<bool> {
+    override_val: Option<BaseMIRValue>,
+) -> DiagnosticResult<MIRVariableReference> {
     if let HIRNodeKind::VarDeclaration {
         variable,
         var_type,
@@ -75,6 +76,8 @@ pub fn lower_hir_variable_declaration(
                     },
                 );
             }
+
+            return Ok(MIRVariableReference::SSAReference(variable));
         } else {
             let lowered = lower_hir_type(ctx, var_type)?;
 
@@ -92,6 +95,17 @@ pub fn lower_hir_variable_declaration(
                 },
             );
 
+            if !default_val.is_some() && override_val.is_some() {
+                let val = override_val.unwrap();
+
+                build_store(
+                    &mut ctx.mir_ctx,
+                    &ctx.hir_ctx.global_scope.scope,
+                    ptr.clone(),
+                    val,
+                )?;
+            }
+
             if default_val.is_some() {
                 let val = lower_hir_value(block_id, default_val.unwrap(), ctx)?;
 
@@ -102,9 +116,9 @@ pub fn lower_hir_variable_declaration(
                     val,
                 )?;
             }
-        }
 
-        return Ok(true);
+            return Ok(MIRVariableReference::PointerReference(ptr.clone()));
+        }
     }
 
     panic!("Invalid node")

--- a/compiler/astoir_mir_lowering/src/vars.rs
+++ b/compiler/astoir_mir_lowering/src/vars.rs
@@ -152,6 +152,12 @@ pub fn lower_hir_deref_modify(
         let ptr = lower_hir_value(block, pointer, ctx)?.as_ptr()?;
         let val = lower_hir_value(block, val, ctx)?;
 
+        println!(
+            "ptr: {}, val: {}",
+            BaseMIRValue::from(ptr.clone().into()).vtype,
+            val.vtype
+        );
+
         let var = MIRVariableReference::PointerReference(ptr);
         var.write(
             block,

--- a/compiler/compiler_main/Cargo.toml
+++ b/compiler/compiler_main/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 astoir = { path = "../astoir" }
+astoir_mir = { path = "../astoir_mir" }
 ast = { path = "../ast" }
 ast_parser = { path = "../ast_parser" }
 lexer = { path = "../lexer" }

--- a/compiler/compiler_main/src/cmds/build.rs
+++ b/compiler/compiler_main/src/cmds/build.rs
@@ -4,6 +4,9 @@ use ast_parser::parse_ast_ctx;
 use astoir::run_astoir_mir;
 use lexer::lexer::lexer_parse_file;
 
+#[cfg(feature = "llvm")]
+use llvm_ir_bridge::bridge_llvm;
+
 use crate::quietlyquit_if_errors;
 
 pub fn build_mir(path: String, out: PathBuf) {
@@ -17,4 +20,25 @@ pub fn build_mir(path: String, out: PathBuf) {
     quietlyquit_if_errors!();
 
     fs::write(out, format!("{}", mir.unwrap())).unwrap();
+}
+
+#[cfg(feature = "llvm")]
+pub fn build_llvm(path: String, out: PathBuf) {
+    let lexer = lexer_parse_file(&path);
+    quietlyquit_if_errors!();
+
+    let ast = parse_ast_ctx(&lexer.unwrap());
+    quietlyquit_if_errors!();
+
+    let mir = run_astoir_mir(ast.unwrap());
+    quietlyquit_if_errors!();
+
+    let llvm = bridge_llvm(&mir.unwrap());
+
+    llvm.module.print_to_file(out).unwrap();
+}
+
+#[cfg(not(feature = "llvm"))]
+pub fn build_llvm(_path: String, _out: PathBuf) {
+    println!("LLVM bridge is disabled in this version of the compiler.")
 }

--- a/compiler/compiler_main/src/cmds/build.rs
+++ b/compiler/compiler_main/src/cmds/build.rs
@@ -2,6 +2,7 @@ use std::{fs, path::PathBuf};
 
 use ast_parser::parse_ast_ctx;
 use astoir::run_astoir_mir;
+use astoir_mir::fmt::DisplayWithCtx;
 use lexer::lexer::lexer_parse_file;
 
 #[cfg(feature = "llvm")]
@@ -19,7 +20,9 @@ pub fn build_mir(path: String, out: PathBuf) {
     let mir = run_astoir_mir(ast.unwrap());
     quietlyquit_if_errors!();
 
-    fs::write(out, format!("{}", mir.unwrap())).unwrap();
+    let mir = mir.unwrap();
+
+    fs::write(out, format!("{}", DisplayWithCtx::new(&mir, &mir))).unwrap();
 }
 
 #[cfg(feature = "llvm")]

--- a/compiler/compiler_main/src/main.rs
+++ b/compiler/compiler_main/src/main.rs
@@ -1,14 +1,13 @@
-use std::{
-    fs,
-    path::PathBuf,
-    time::Instant,
-};
+use std::{fs, path::PathBuf, time::Instant};
 
 use clap::Parser;
 
 use crate::{
     cli::{Bridge, CLICommand, Cli, OutputFormat},
-    cmds::{build::build_mir, check::run_check},
+    cmds::{
+        build::{build_llvm, build_mir},
+        check::run_check,
+    },
     version::{GIT_HASH, VERSION},
 };
 
@@ -74,7 +73,15 @@ fn main() {
                     }
                 }
 
-                _ => todo!(),
+                Bridge::LLVM => {
+                    for i in input {
+                        let mut outfile = PathBuf::from(i.file_name().unwrap());
+                        outfile.add_extension("ll");
+
+                        let output_path = out.join(outfile);
+                        build_llvm(i.to_str().unwrap().to_string(), output_path);
+                    }
+                }
             }
         }
 

--- a/compiler/compiler_typing/src/raw.rs
+++ b/compiler/compiler_typing/src/raw.rs
@@ -140,6 +140,14 @@ impl RawType {
         }
     }
 
+    pub fn is_struct(&self) -> bool {
+        match self {
+            Self::Struct(_, _) => true,
+            Self::LoweredStruct(_, _) => true,
+            _ => false,
+        }
+    }
+
     pub fn has_trait(&self, t: Trait, raw_type: &Type) -> bool {
         match t {
             Trait::Integer => self.is_integer(),

--- a/compiler/compiler_typing/src/tree.rs
+++ b/compiler/compiler_typing/src/tree.rs
@@ -54,6 +54,14 @@ impl Type {
         }
     }
 
+    pub fn is_generic_direct(&self) -> bool {
+        match self {
+            Self::Generic(_, _, _) => true,
+            Self::GenericLowered(_) => true,
+            _ => false,
+        }
+    }
+
     pub fn is_ptr(&self) -> bool {
         match self {
             Self::Pointer(_, _) => true,

--- a/compiler/compiler_typing/src/tree.rs
+++ b/compiler/compiler_typing/src/tree.rs
@@ -62,6 +62,15 @@ impl Type {
         }
     }
 
+    pub fn is_struct(&self) -> bool {
+        match self {
+            Self::GenericLowered(inner) => inner.is_struct(),
+            Self::Generic(inner, _, _) => inner.is_struct(),
+
+            _ => false,
+        }
+    }
+
     pub fn is_ptr(&self) -> bool {
         match self {
             Self::Pointer(_, _) => true,
@@ -122,6 +131,9 @@ impl Type {
 
                 return base == base2;
             }
+
+            (Self::Pointer(_, _), Self::GenericLowered(base)) => return *base == RawType::Pointer,
+            (Self::GenericLowered(base), Self::Pointer(_, _)) => return *base == RawType::Pointer,
 
             _ => false,
         }

--- a/compiler/diagnostics/src/builders.rs
+++ b/compiler/diagnostics/src/builders.rs
@@ -4,12 +4,13 @@ use crate::{
     DiagnosticSpanOrigin,
     diagnostic::{Diagnostic, Level, Span, SpanKind, SpanPosition},
     errors::{
-        ALREADY_IN_SCOPE, ASSIGN_DIFF_TYPE_IR, BOUND_MISSING, CANNOT_FIND, DIFF_SIZE_SPECIFIERS,
-        DIFF_TYPE_SPECIFIERS, ENUM_PARENT_FIELDS, ERA_NOT_EXIST, EXPECTED_FREE, EXPECTED_TOKEN,
-        EXPECTED_TYPE, FIELD_MISSING, FIELD_STRUCT_INIT, FIND_TYPE, FIND_TYPE_FIELD,
-        FIND_TYPE_FUNCTION, FIND_VAR, FUNC_MISSING, INDEX_USAGE, INVALID_POINTING,
-        INVALID_TYPE_REQ, IR_CAST, IR_INSTRUCTION_HELD_VAL, MATH_OPERATION_ASSIGNS, NOT_FOUND_USE,
-        TRAIT_MISSING, TYPE_NOT_PART, UNEXPECTED_TOKEN, VARIABLE_UNINIT,
+        ALREADY_IN_SCOPE, ASSIGN_DIFF_TYPE_IR, BOUND_MISSING, CANNOT_FIND, CODE_UNREACHABLE,
+        DIFF_SIZE_SPECIFIERS, DIFF_TYPE_SPECIFIERS, ENDING_POINT_MISSING, ENUM_PARENT_FIELDS,
+        ERA_NOT_EXIST, EXPECTED_FREE, EXPECTED_TOKEN, EXPECTED_TYPE, FIELD_MISSING,
+        FIELD_STRUCT_INIT, FIND_TYPE, FIND_TYPE_FIELD, FIND_TYPE_FUNCTION, FIND_VAR, FUNC_MISSING,
+        INDEX_USAGE, INVALID_POINTING, INVALID_TYPE_REQ, IR_CAST, IR_INSTRUCTION_HELD_VAL,
+        MATH_OPERATION_ASSIGNS, NOT_FOUND_USE, TRAIT_MISSING, TYPE_NOT_PART, UNEXPECTED_TOKEN,
+        VARIABLE_UNINIT,
     },
     get_current_diagnostic_pos,
     warnings::UNUSED_VAR,
@@ -639,5 +640,32 @@ pub fn make_cannot_find<K: DiagnosticSpanOrigin, P: Display>(
         vec![],
         vec![],
         vec![],
+    )
+}
+
+pub fn make_ending_point_missing<K: DiagnosticSpanOrigin>(origin: &K) -> Diagnostic {
+    origin.make_simple_diagnostic(
+        ENDING_POINT_MISSING.0,
+        Level::Error,
+        ENDING_POINT_MISSING.1.to_string(),
+        None,
+        vec![],
+        vec![
+            "an ending point (eg: return statement) is missing on a function that must return"
+                .to_string(),
+        ],
+        vec!["try adding a ret statement".to_string()],
+    )
+}
+
+pub fn make_unreachable_code<K: DiagnosticSpanOrigin>(origin: &K) -> Diagnostic {
+    origin.make_simple_diagnostic(
+        CODE_UNREACHABLE.0,
+        Level::Error,
+        CODE_UNREACHABLE.1.to_string(),
+        None,
+        vec![],
+        vec!["an ending point (eg: return statement) was previously introduced, this code is then unreachable".to_string()],
+        vec!["move this code before the ending point".to_string()],
     )
 }

--- a/compiler/diagnostics/src/builders.rs
+++ b/compiler/diagnostics/src/builders.rs
@@ -9,8 +9,8 @@ use crate::{
         ERA_NOT_EXIST, EXPECTED_FREE, EXPECTED_TOKEN, EXPECTED_TYPE, FIELD_MISSING,
         FIELD_STRUCT_INIT, FIND_TYPE, FIND_TYPE_FIELD, FIND_TYPE_FUNCTION, FIND_VAR, FUNC_MISSING,
         INDEX_USAGE, INVALID_POINTING, INVALID_TYPE_REQ, IR_CAST, IR_INSTRUCTION_HELD_VAL,
-        MATH_OPERATION_ASSIGNS, NOT_FOUND_USE, TRAIT_MISSING, TYPE_NOT_PART, UNEXPECTED_TOKEN,
-        VARIABLE_UNINIT,
+        MATH_OPERATION_ASSIGNS, NOT_FOUND_USE, RET_TYPE_NOT_MATCH, TRAIT_MISSING, TYPE_NOT_PART,
+        UNEXPECTED_TOKEN, VARIABLE_UNINIT,
     },
     get_current_diagnostic_pos,
     warnings::UNUSED_VAR,
@@ -667,5 +667,17 @@ pub fn make_unreachable_code<K: DiagnosticSpanOrigin>(origin: &K) -> Diagnostic 
         vec![],
         vec!["an ending point (eg: return statement) was previously introduced, this code is then unreachable".to_string()],
         vec!["move this code before the ending point".to_string()],
+    )
+}
+
+pub fn make_ret_type_kind<K: DiagnosticSpanOrigin>(origin: &K) -> Diagnostic {
+    origin.make_simple_diagnostic(
+        RET_TYPE_NOT_MATCH.0,
+        Level::Error,
+        RET_TYPE_NOT_MATCH.1.to_string(),
+        None,
+        vec![],
+        vec![],
+        vec![],
     )
 }

--- a/compiler/diagnostics/src/errors.rs
+++ b/compiler/diagnostics/src/errors.rs
@@ -105,3 +105,8 @@ declare_error!(NOT_FOUND_USE, 32, "element {} was not found in {}");
 declare_error!(CANNOT_FIND, 33, "cannot find {} in the current scope");
 declare_error!(ENDING_POINT_MISSING, 34, "missing ending point.");
 declare_error!(CODE_UNREACHABLE, 35, "unreachable code.");
+declare_error!(
+    RET_TYPE_NOT_MATCH,
+    36,
+    "different return type kinds. one is empty and one is not."
+);

--- a/compiler/diagnostics/src/errors.rs
+++ b/compiler/diagnostics/src/errors.rs
@@ -39,7 +39,7 @@ declare_error!(
     10,
     "functions are not supported in layouts"
 );
-declare_error!(INVALID_POINTING, 11, "cannot point to a non-variable");
+declare_error!(INVALID_POINTING, 11, "cannot dereference non-pointer");
 declare_error!(
     TRAIT_MISSING,
     12,

--- a/compiler/diagnostics/src/errors.rs
+++ b/compiler/diagnostics/src/errors.rs
@@ -103,3 +103,5 @@ declare_error!(INVALID_TYPE_REQ, 30, "this operation requires a {} type");
 declare_error!(TYPE_NOT_PART, 31, "type {} is not part of type {}");
 declare_error!(NOT_FOUND_USE, 32, "element {} was not found in {}");
 declare_error!(CANNOT_FIND, 33, "cannot find {} in the current scope");
+declare_error!(ENDING_POINT_MISSING, 34, "missing ending point.");
+declare_error!(CODE_UNREACHABLE, 35, "unreachable code.");

--- a/compiler/lexer/src/lexer.rs
+++ b/compiler/lexer/src/lexer.rs
@@ -11,7 +11,7 @@ use diagnostics::diagnostic::SpanPosition;
 
 use crate::token::{LexerToken, LexerTokenType};
 
-const SHADOWFUNC_KEYWORD_HASH: u64 = hash!("shadowfunc");
+const EXTERNFUNC_KEYWORD_HASH: u64 = hash!("externfunc");
 const FUNC_KEYWORD_HASH: u64 = hash!("func");
 const RET_KEYWORD_HASH: u64 = hash!("ret");
 const VAR_KEYWORD_HASH: u64 = hash!("var");
@@ -351,11 +351,10 @@ fn parse_keyword(str: &String, ind: &mut usize, start_pos: Position) -> LexerTok
 
     let token_type = match hash {
         FUNC_KEYWORD_HASH => LexerTokenType::Function,
-        SHADOWFUNC_KEYWORD_HASH => LexerTokenType::ShadowFunction,
+        EXTERNFUNC_KEYWORD_HASH => LexerTokenType::ExternFunc,
         RET_KEYWORD_HASH => LexerTokenType::Return,
         STRUCT_KEYWORD_HASH => LexerTokenType::Struct,
         LAYOUT_KEYWORD_HASH => LexerTokenType::Layout,
-        LAY_KEYWORD_HASH => LexerTokenType::Lay,
         TRUE_KEYWORD_HASH => LexerTokenType::True,
         FALSE_KEYWORD_HASH => LexerTokenType::False,
         VAR_KEYWORD_HASH => LexerTokenType::Var,

--- a/compiler/lexer/src/lexer.rs
+++ b/compiler/lexer/src/lexer.rs
@@ -17,7 +17,6 @@ const RET_KEYWORD_HASH: u64 = hash!("ret");
 const VAR_KEYWORD_HASH: u64 = hash!("var");
 const STRUCT_KEYWORD_HASH: u64 = hash!("struct");
 const LAYOUT_KEYWORD_HASH: u64 = hash!("layout");
-const LAY_KEYWORD_HASH: u64 = hash!("lay");
 const FALSE_KEYWORD_HASH: u64 = hash!("false");
 const TRUE_KEYWORD_HASH: u64 = hash!("true");
 const IF_KEYWORD_HASH: u64 = hash!("if");

--- a/compiler/lexer/src/lexer.rs
+++ b/compiler/lexer/src/lexer.rs
@@ -178,6 +178,10 @@ pub fn lexer_parse(contents: String, file_path: &String) -> DiagnosticResult<Vec
             '-' => tokens.push(LexerToken::make_single_sized(pos, LexerTokenType::Minus)),
             '/' => tokens.push(LexerToken::make_single_sized(pos, LexerTokenType::Divide)),
             '~' => tokens.push(LexerToken::make_single_sized(pos, LexerTokenType::Tidle)),
+            ';' => tokens.push(LexerToken::make_single_sized(
+                pos,
+                LexerTokenType::SemiCollon,
+            )),
             '%' => tokens.push(LexerToken::make_single_sized(
                 pos,
                 LexerTokenType::PercentSign,

--- a/compiler/lexer/src/token.rs
+++ b/compiler/lexer/src/token.rs
@@ -16,7 +16,7 @@ use diagnostics::{
 pub enum LexerTokenType {
     /// Represent the func keyword
     Function,
-    ShadowFunction,
+    ExternFunc,
 
     Comment(String),
     GlobalComment(String),
@@ -216,7 +216,7 @@ impl Display for LexerTokenType {
             Self::ParenClose => ")",
             Self::ParenOpen => "(",
             Self::Return => "ret",
-            Self::ShadowFunction => "shadowfunc",
+            Self::ExternFunc => "externfunc",
             Self::Static => "static",
             Self::StringLit(_) => "string literal",
             Self::Var => "var",

--- a/compiler/lexer/src/token.rs
+++ b/compiler/lexer/src/token.rs
@@ -59,6 +59,7 @@ pub enum LexerTokenType {
     Dot,
     Ampersand,
     Collon,
+    SemiCollon,
 
     Plus,
     Minus,
@@ -194,6 +195,7 @@ impl Display for LexerTokenType {
             Self::ArrayOpen => "[",
             Self::Asterisk => "*",
             Self::Collon => ":",
+            Self::SemiCollon => ";",
             Self::BracketClose => "}",
             Self::BracketOpen => "{",
             Self::Comma => ",",

--- a/compiler/llvm_ir_bridge/src/ctx.rs
+++ b/compiler/llvm_ir_bridge/src/ctx.rs
@@ -14,7 +14,7 @@ pub struct LLVMBridgeContext {
     pub blocks: HashMap<usize, LLVMBlock>,
     pub values: HashMap<usize, LLVMBasicValue>,
     pub completed_blocks: HashSet<usize>,
-    pub functions: Vec<LLVMFunction>,
+    pub functions: HashMap<usize, LLVMFunction>,
 
     pub types: LLVMTypeStorage,
 
@@ -32,7 +32,7 @@ impl LLVMBridgeContext {
             blocks: HashMap::new(),
             completed_blocks: HashSet::new(),
             types: LLVMTypeStorage::new(&ctx),
-            functions: vec![],
+            functions: HashMap::new(),
             void_type: unsafe { transmute::<VoidType, VoidType<'static>>(ctx.void_type()) },
             values: HashMap::new(),
             ctx: ctx.clone(),

--- a/compiler/llvm_ir_bridge/src/funcs.rs
+++ b/compiler/llvm_ir_bridge/src/funcs.rs
@@ -11,6 +11,8 @@ use crate::{
 pub fn bridge_llvm_functions(mir: &MIRContext, bridge: &mut LLVMBridgeContext) {
     for func in &mir.functions {
         let mut args = vec![];
+        let ind = func.0;
+
         let func = func.1;
 
         if !func.blocks.is_empty() {
@@ -35,6 +37,6 @@ pub fn bridge_llvm_functions(mir: &MIRContext, bridge: &mut LLVMBridgeContext) {
             );
         }
 
-        bridge.functions.push(LLVMFunction::new(ff));
+        bridge.functions.insert(*ind, LLVMFunction::new(ff));
     }
 }

--- a/compiler/llvm_ir_bridge/src/insts.rs
+++ b/compiler/llvm_ir_bridge/src/insts.rs
@@ -49,6 +49,23 @@ pub fn bridge_llvm_instruction(
                 Some(res.into())
             }
 
+            MIRInstruction::DerefPointer { ptr } => {
+                let base = BaseMIRValue::from(ptr.into());
+
+                let res = llvm_to_base!(
+                    bridge.builder.build_load(
+                        bridge
+                            .types
+                            .convert(mir.ssa_hints.get_hint(base.get_ssa_index()).get_type())
+                            .inner,
+                        bridge.values[&base.get_ssa_index()].into_pointer_value(),
+                        &format!("{}", instruction.as_valuedindex())
+                    )
+                );
+
+                Some(res.into())
+            }
+
             MIRInstruction::Store { variable, value } => {
                 let base = BaseMIRValue::from(variable.into());
                 let ptr = bridge.values[&base.get_ssa_index()].into_pointer_value();

--- a/compiler/llvm_ir_bridge/src/insts.rs
+++ b/compiler/llvm_ir_bridge/src/insts.rs
@@ -888,7 +888,7 @@ pub fn bridge_llvm_instruction(
                 function,
                 arguments,
             } => {
-                let func = bridge.functions[function].clone().inner;
+                let func = bridge.functions[&function].clone().inner;
 
                 let mut args = vec![];
 
@@ -902,7 +902,7 @@ pub fn bridge_llvm_instruction(
             }
 
             MIRInstruction::FuncArgumentGrab { ind, argtype: _ } => {
-                let func = bridge.functions[func].clone().inner;
+                let func = bridge.functions[&func].clone().inner;
 
                 func.get_nth_param(ind as u32)
             }

--- a/examples/control.qf
+++ b/examples/control.qf
@@ -1,0 +1,17 @@
+func multiply_number(s32 a, s32 b) -> s32 {
+	mut s32 res = 0;
+
+	for(i => [0..b]) {
+		res += b;
+	}
+
+	return res;
+}
+
+func check_number(s32 test) -> bool {
+	if(test <= 53) {
+		return true;
+	}
+
+	return false;
+}

--- a/examples/control.qf
+++ b/examples/control.qf
@@ -1,7 +1,7 @@
 func multiply_number(s32 a, s32 b) -> s32 {
 	mut s32 res = 0;
 
-	for(i => [0..b]) {
+	for(s32 i => [0..b]) {
 		res += b;
 	}
 

--- a/examples/control.qf
+++ b/examples/control.qf
@@ -1,7 +1,7 @@
 func multiply_number(s32 a, s32 b) -> s32 {
 	mut s32 res = 0;
 
-	for(s32 i => [0..b]) {
+	for s32 i => [0..b] {
 		res += b;
 	}
 

--- a/examples/extern.qf
+++ b/examples/extern.qf
@@ -1,0 +1,5 @@
+externfunc printf(ptr fmt, ...);
+
+func main() -> s32 {
+	printf("Hello World! From %d", 52)
+}

--- a/examples/helloworld.qf
+++ b/examples/helloworld.qf
@@ -1,0 +1,11 @@
+use std::[print]
+
+func main() -> s32 {
+	mut s32 test2 = 69;
+
+	test2 = 120; // Mutable
+
+	var s32 test3 = 69; // Not mutable
+
+	print("Hello world!");
+}

--- a/examples/math.qf
+++ b/examples/math.qf
@@ -1,0 +1,11 @@
+func main() -> s32 {
+	var s32 add = 1 + 1
+	var s32 sub = 1 - 1
+	var s32 mul = 1 * 1
+	var s32 div = 1 / 1
+	var s32 mod = 1 \ 1
+	var s32 or = 1 -- 1
+	var s32 and = 1 ++ 1
+	var s32 xor = 1 !! 1
+	var s32 xnor = 1 ?? 1
+}

--- a/examples/pointers.qf
+++ b/examples/pointers.qf
@@ -1,0 +1,11 @@
+// In arguments, mut can only be used on pointers to decide 
+// if a pointer is mutable or immutable
+func move_from_pointer(mut s32* a, mut s32* b) { 
+	var s32 origin = *a // Gets the value of a
+	var s32 second = *b // gets the value of b
+
+	var s32*[] myPointerArray; // Represents a pointer based array. That can use indexing like an array
+
+	*b = origin // Changes the value of b
+	*a = second // Changes the value of a 
+}

--- a/examples/structs.qf
+++ b/examples/structs.qf
@@ -1,0 +1,14 @@
+struct my_struct {
+	s32 field_a
+	bool field_b
+}
+
+decl my_struct {
+	func test(self) -> bool {
+		return self.field_b && self.field_a >= 50;
+	}
+
+	func new() -> my_struct {
+		return { field_a: 0, field_b: false } 
+	}
+}

--- a/examples/type_params.qf
+++ b/examples/type_params.qf
@@ -1,0 +1,13 @@
+// Type parameters are only available on structs and functions but can only be used for pointers and storage. Any other operation (eg: math) is forbidden
+
+struct vector<K> {
+	K*[] pointer
+	u0 counter
+}
+
+decl vector {
+	func add(self, K v) { 
+		self.pointer[self.counter] = v
+		self.counter += 1
+	}
+}


### PR DESCRIPTION
**Changelog**:
- Added new syntax
- Removed lay token
- Renamed shadow functions to extern functions
- Added ranged for loop
- Added experimental pointer dereference & dereference modify
- Added semicolon in lexer
- Added ending point enforcing
- Added back SSA capabilities for non-struct, non-mutable variables
- Fixed some MIR casting bugs with pointers
- Made `stkalloc` use more precise types to prevent lossy types in the MIR